### PR TITLE
Adjust auth cookie path and add diagnostics for /me requests

### DIFF
--- a/backend/auth_callback/lambda_function.py
+++ b/backend/auth_callback/lambda_function.py
@@ -37,9 +37,10 @@ STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token"
 
 # Extract path from API_BASE_URL for cookie Path attribute
 # API_BASE_URL format: https://domain.com/stage or https://domain.com
-# We need the path portion (e.g., /stage) for cookies to work with API Gateway
+# Use a root path to avoid path mismatches across stages.
 _parsed_api_base = urlparse(API_BASE) if API_BASE else None
-COOKIE_PATH = _parsed_api_base.path if _parsed_api_base and _parsed_api_base.path else "/"
+API_BASE_PATH = _parsed_api_base.path if _parsed_api_base and _parsed_api_base.path else ""
+COOKIE_PATH = "/"
 
 
 def _parse_cookies(event: dict) -> dict:
@@ -116,6 +117,9 @@ def handler(event, context):
     code = qs.get("code")
     state = qs.get("state")
     err = qs.get("error")
+    if API_BASE_PATH:
+        print(f"Debug - API_BASE_URL path detected: {API_BASE_PATH}")
+    print(f"Debug - Cookie path configured as: {COOKIE_PATH}")
 
     if err:
         # Strava can return access_denied if user cancels

--- a/backend/auth_disconnect/lambda_function.py
+++ b/backend/auth_disconnect/lambda_function.py
@@ -29,9 +29,10 @@ APP_SECRET = APP_SECRET_STR.encode() if APP_SECRET_STR else b""
 
 # Extract path from API_BASE_URL for cookie Path attribute
 # API_BASE_URL format: https://domain.com/stage or https://domain.com
-# We need the path portion (e.g., /stage) for cookies to work with API Gateway
+# Use a root path to avoid path mismatches across stages.
 _parsed_api_base = urlparse(API_BASE) if API_BASE else None
-COOKIE_PATH = _parsed_api_base.path if _parsed_api_base and _parsed_api_base.path else "/"
+API_BASE_PATH = _parsed_api_base.path if _parsed_api_base and _parsed_api_base.path else ""
+COOKIE_PATH = "/"
 
 
 def _parse_cookies(event: dict) -> dict:
@@ -96,6 +97,9 @@ def _exec_sql(sql: str, parameters: list = None):
 
 
 def handler(event, context):
+    if API_BASE_PATH:
+        print(f"Debug - API_BASE_URL path detected: {API_BASE_PATH}")
+    print(f"Debug - Cookie path configured as: {COOKIE_PATH}")
     cookies = _parse_cookies(event)
     session = cookies.get("rm_session")
     if not session:

--- a/backend/auth_start/lambda_function.py
+++ b/backend/auth_start/lambda_function.py
@@ -22,9 +22,10 @@ DB_NAME = os.environ.get("DB_NAME", "postgres")
 
 # Extract path from API_BASE_URL for cookie Path attribute
 # API_BASE_URL format: https://domain.com/stage or https://domain.com
-# We need the path portion (e.g., /stage) for cookies to work with API Gateway
+# Use a root path to avoid path mismatches across stages.
 _parsed_api_base = urlparse(API_BASE) if API_BASE else None
-COOKIE_PATH = _parsed_api_base.path if _parsed_api_base and _parsed_api_base.path else "/"
+API_BASE_PATH = _parsed_api_base.path if _parsed_api_base and _parsed_api_base.path else ""
+COOKIE_PATH = "/"
 
 def _exec_sql(sql: str, parameters: list | None = None):
     kwargs = {
@@ -54,6 +55,9 @@ def handler(event, context):
             "headers": {"Content-Type": "application/json"},
             "body": '{"error": "Server configuration error. Please contact support at tim@rabbitmiles.com."}'
         }
+    if API_BASE_PATH:
+        print(f"Debug - API_BASE_URL path detected: {API_BASE_PATH}")
+    print(f"Debug - Cookie path configured as: {COOKIE_PATH}")
     
     state = secrets.token_urlsafe(24)
     

--- a/backend/me/lambda_function.py
+++ b/backend/me/lambda_function.py
@@ -147,10 +147,26 @@ def handler(event, context):
         headers = event.get("headers") or {}
         cookies_array = event.get("cookies") or []
         cookie_header = headers.get("cookie") or headers.get("Cookie")
+        origin_header = headers.get("origin") or headers.get("Origin") or ""
+        referer_header = headers.get("referer") or headers.get("Referer") or ""
+        host_header = headers.get("host") or headers.get("Host") or ""
+        sec_fetch_site = headers.get("sec-fetch-site") or headers.get("Sec-Fetch-Site") or ""
+        sec_fetch_mode = headers.get("sec-fetch-mode") or headers.get("Sec-Fetch-Mode") or ""
+        sec_fetch_dest = headers.get("sec-fetch-dest") or headers.get("Sec-Fetch-Dest") or ""
+        sec_fetch_storage = headers.get("sec-fetch-storage-access") or headers.get("Sec-Fetch-Storage-Access") or ""
         
         # Log presence of cookies without exposing values
         print(f"Debug - cookies array present: {len(cookies_array) > 0}, count: {len(cookies_array)}")
         print(f"Debug - cookie header present: {cookie_header is not None}")
+        if cookie_header:
+            print(f"Debug - cookie header length: {len(cookie_header)}")
+        print(f"Debug - Origin: {origin_header}")
+        print(f"Debug - Referer: {referer_header}")
+        print(f"Debug - Host: {host_header}")
+        print(f"Debug - Sec-Fetch-Site: {sec_fetch_site}")
+        print(f"Debug - Sec-Fetch-Mode: {sec_fetch_mode}")
+        print(f"Debug - Sec-Fetch-Dest: {sec_fetch_dest}")
+        print(f"Debug - Sec-Fetch-Storage-Access: {sec_fetch_storage}")
         if cookies_array:
             # Log cookie names only, not values
             all_cookie_names = []


### PR DESCRIPTION
### Motivation
- New user sessions were failing because cookies set on a stage-specific API path were not being sent to the frontend and `/me` returned 401 with insufficient diagnostics. 
- More detailed request and cookie headers are needed in `/me` logs to diagnose cross-site cookie, CORS and browser header interactions.

### Description
- Use a root cookie path by setting `COOKIE_PATH = "/"` and introduce `API_BASE_PATH` to detect any API stage path in `backend/auth_start/lambda_function.py`, `backend/auth_callback/lambda_function.py`, and `backend/auth_disconnect/lambda_function.py`.
- Add debug logging for `API_BASE_PATH` and `COOKIE_PATH` in the auth start/callback/disconnect flows to surface path configuration at runtime.
- Expand `/me` diagnostics in `backend/me/lambda_function.py` to log `Origin`, `Referer`, `Host`, `Sec-Fetch-*` headers, the `cookie` header length, and cookie name lists (without values) to aid troubleshooting of missing-session cases.
- Kept cookie attributes (HttpOnly, Secure, SameSite=None, Partitioned) intact while making the path consistent across stages.

### Testing
- No automated tests were executed for this change.
- Changes were committed and are intended to improve diagnostics when exercising the auth flows in staging/production environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6983f1aaee4483228209a15d28d71241)