### PR TITLE
Cut Strava read-API usage and stop autofetch from DLQing on 429s

### DIFF
--- a/backend/migrations/011_add_last_webhook_received.sql
+++ b/backend/migrations/011_add_last_webhook_received.sql
@@ -1,0 +1,12 @@
+-- Add last_webhook_received_at column to users table
+-- This records the timestamp of the most recent successfully-processed Strava
+-- webhook event for each user, allowing the hourly scheduled_activity_update
+-- backstop to skip users whose data is already being kept current via webhooks.
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS last_webhook_received_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_users_last_webhook_received_at
+    ON users(last_webhook_received_at);
+
+COMMENT ON COLUMN users.last_webhook_received_at IS 'Timestamp of the last successfully-processed Strava webhook event for this user. Used by the hourly scheduled poll to skip users already covered by webhooks.';

--- a/backend/scheduled_activity_update/lambda_function.py
+++ b/backend/scheduled_activity_update/lambda_function.py
@@ -17,6 +17,7 @@ import boto3
 
 rds = boto3.client("rds-data")
 sm = boto3.client("secretsmanager")
+lambda_client = boto3.client("lambda")
 
 # Logging constants
 SEPARATOR_LINE = "=" * 80
@@ -34,7 +35,6 @@ DB_NAME = None
 
 STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token"
 STRAVA_ACTIVITIES_URL = "https://www.strava.com/api/v3/athlete/activities"
-STRAVA_ATHLETE_URL = "https://www.strava.com/api/v3/athlete"
 
 # Filter activities starting from Jan 1, 2026 00:00:00 UTC
 # Unix timestamp: 1767225600
@@ -56,8 +56,21 @@ RATE_LIMIT_SAFETY_MARGIN = 5
 # Maximum retries on HTTP 429
 MAX_RETRIES = 3
 
-# Maximum wait time between retries (15 minutes = one Strava rate limit window)
-MAX_RETRY_WAIT_SECONDS = 900
+# Maximum wait time between retries (capped well below Lambda's 15-min hard cap so a
+# single bad user can't time out the entire batch). Above this, we abort the run
+# and let the next scheduled invocation pick up where we left off.
+MAX_RETRY_WAIT_SECONDS = 120
+
+# Skip users whose data was already kept fresh by webhooks within this window.
+# The hourly job is only a backstop for missed webhooks.
+WEBHOOK_FRESHNESS_SECONDS = 6 * 60 * 60  # 6 hours
+
+# How many users to process per invocation. If more users remain, we self-invoke
+# the lambda to continue, so one Lambda execution never spans more than this many.
+USERS_PER_INVOCATION = 25
+
+# Stop processing and self-continue when remaining Lambda time drops below this.
+LAMBDA_TIME_REMAINING_SAFETY_MS = 90 * 1000  # 90 seconds
 
 
 def _get_strava_creds():
@@ -174,22 +187,48 @@ def _update_rate_limit_from_headers(headers):
             pass
 
 
-def _wait_if_rate_limited():
-    """Pause if we are approaching Strava's 15-minute rate limit."""
+class RateLimitExhaustedError(Exception):
+    """Raised when we'd need to wait longer than is safe inside this Lambda
+    invocation. The caller should stop processing and let the next scheduled
+    run pick up the rest."""
+
+
+def _seconds_until_lambda_deadline(context):
+    """Return remaining ms in the current Lambda invocation, or +inf if no context."""
+    if context and hasattr(context, "get_remaining_time_in_millis"):
+        try:
+            return context.get_remaining_time_in_millis()
+        except Exception:
+            return float("inf")
+    return float("inf")
+
+
+def _wait_if_rate_limited(context=None):
+    """Pause if we are approaching Strava's 15-minute rate limit.
+
+    Raises RateLimitExhaustedError when sleeping would exceed our remaining
+    Lambda budget; the caller should abort and let the next run continue.
+    """
     global _rate_limit_used
     if _rate_limit_used >= _rate_limit_limit - RATE_LIMIT_SAFETY_MARGIN:
         now = time.time()
         seconds_into_window = now % (15 * 60)
         wait = (15 * 60) - seconds_into_window + 5  # +5s buffer
+
+        remaining_ms = _seconds_until_lambda_deadline(context)
+        if wait * 1000 > remaining_ms - LAMBDA_TIME_REMAINING_SAFETY_MS:
+            log(f"Rate limit hit and {wait:.0f}s wait exceeds remaining Lambda time ({remaining_ms/1000:.0f}s); aborting batch", "WARNING")
+            raise RateLimitExhaustedError("not enough Lambda time to wait out rate limit window")
+
         log(f"Rate limit approaching ({_rate_limit_used}/{_rate_limit_limit}), sleeping {wait:.0f}s for window reset", "WARNING")
         time.sleep(wait)
         _rate_limit_used = 0
 
 
-def _strava_get(req, timeout=30):
+def _strava_get(req, context=None, timeout=30):
     """Shared Strava GET with rate-limit awareness and 429 retry."""
     for attempt in range(MAX_RETRIES + 1):
-        _wait_if_rate_limited()
+        _wait_if_rate_limited(context)
         try:
             with urlopen(req, timeout=timeout) as resp:
                 body = resp.read().decode()
@@ -199,19 +238,23 @@ def _strava_get(req, timeout=30):
             if e.code == 429:
                 if attempt < MAX_RETRIES:
                     wait = min(60 * (2 ** attempt), MAX_RETRY_WAIT_SECONDS)
+                    remaining_ms = _seconds_until_lambda_deadline(context)
+                    if wait * 1000 > remaining_ms - LAMBDA_TIME_REMAINING_SAFETY_MS:
+                        log(f"429 received but {wait}s retry exceeds remaining Lambda time; aborting", "WARNING")
+                        raise RateLimitExhaustedError("not enough Lambda time to retry after 429") from e
                     log(f"429 received, retrying in {wait}s (attempt {attempt + 1}/{MAX_RETRIES})", "WARNING")
                     time.sleep(wait)
                     continue
             raise
 
 
-def fetch_strava_activities(access_token, after_timestamp, per_page=200):
+def fetch_strava_activities(access_token, after_timestamp, context=None, per_page=200):
     """Fetch activities from Strava API after a given timestamp"""
     url = f"{STRAVA_ACTIVITIES_URL}?per_page={per_page}&page=1&after={after_timestamp}"
     req = Request(url, headers={"Authorization": f"Bearer {access_token}"})
-    
+
     try:
-        activities = _strava_get(req, timeout=30)
+        activities = _strava_get(req, context=context, timeout=30)
         log(f"Fetched {len(activities) if isinstance(activities, list) else 'non-list'} activities from Strava", "INFO")
         return activities
     except Exception as e:
@@ -225,58 +268,6 @@ def fetch_strava_activities(access_token, after_timestamp, per_page=200):
             except Exception:
                 pass
         raise
-
-
-def fetch_strava_athlete(access_token):
-    """Fetch athlete profile from Strava API"""
-    req = Request(STRAVA_ATHLETE_URL, headers={"Authorization": f"Bearer {access_token}"})
-    
-    try:
-        athlete = _strava_get(req, timeout=20)
-        log("Fetched athlete profile from Strava", "INFO")
-        return athlete
-    except Exception as e:
-        log(f"Failed to fetch athlete profile from Strava: {e}", "WARNING")
-        if hasattr(e, 'code'):
-            log(f"Athlete profile HTTP status code: {e.code}", "WARNING")
-        if hasattr(e, 'read'):
-            try:
-                error_body = e.read().decode()
-                log(f"Athlete profile error response: {error_body}", "WARNING")
-            except Exception:
-                pass
-        return None
-
-
-def update_user_profile_picture(athlete_id, athlete):
-    """Update user profile picture in the database"""
-    if not isinstance(athlete, dict):
-        return False
-    
-    profile_picture = athlete.get("profile_medium") or athlete.get("profile") or ""
-    
-    sql = """
-    UPDATE users
-    SET profile_picture = :pic,
-        updated_at = now()
-    WHERE athlete_id = :aid
-    """
-    params = [
-        {"name": "aid", "value": {"longValue": athlete_id}},
-    ]
-    
-    if profile_picture:
-        params.append({"name": "pic", "value": {"stringValue": profile_picture}})
-    else:
-        params.append({"name": "pic", "value": {"isNull": True}})
-    
-    try:
-        _exec_sql(sql, params)
-        log(f"Updated profile picture for athlete {athlete_id}", "INFO")
-        return True
-    except Exception as e:
-        log(f"Failed to update profile picture for athlete {athlete_id}: {e}", "WARNING")
-        return False
 
 
 def store_activity(athlete_id, activity):
@@ -358,25 +349,47 @@ def store_activity(athlete_id, activity):
         return False
 
 
-def get_all_connected_users():
-    """Get all users with valid Strava tokens"""
-    sql = """
-    SELECT athlete_id, access_token, refresh_token, expires_at 
-    FROM users 
-    WHERE access_token IS NOT NULL 
+def get_users_needing_poll():
+    """Get connected users that webhooks have not kept fresh recently.
+
+    Skips users whose last_webhook_received_at is within WEBHOOK_FRESHNESS_SECONDS
+    so we only poll the backstop set, not every connected user. Users that have
+    never received a webhook are always included.
+
+    Falls back to "all connected users" if the column does not yet exist
+    (so this works before migration 011 has run).
+    """
+    sql_with_filter = f"""
+    SELECT athlete_id, access_token, refresh_token, expires_at
+    FROM users
+    WHERE access_token IS NOT NULL
+      AND refresh_token IS NOT NULL
+      AND (
+        last_webhook_received_at IS NULL
+        OR last_webhook_received_at < NOW() - INTERVAL '{WEBHOOK_FRESHNESS_SECONDS} seconds'
+      )
+    ORDER BY athlete_id
+    """
+    sql_fallback = """
+    SELECT athlete_id, access_token, refresh_token, expires_at
+    FROM users
+    WHERE access_token IS NOT NULL
       AND refresh_token IS NOT NULL
     ORDER BY athlete_id
     """
-    result = _exec_sql(sql)
-    
+    try:
+        result = _exec_sql(sql_with_filter)
+    except Exception as e:
+        log(f"last_webhook_received_at filter failed ({e}); falling back to all connected users", "WARNING")
+        result = _exec_sql(sql_fallback)
+
     users = []
-    records = result.get("records", [])
-    for record in records:
+    for record in result.get("records", []):
         athlete_id = int(record[0].get("longValue", 0))
         access_token = record[1].get("stringValue", "")
         refresh_token = record[2].get("stringValue", "")
         expires_at = int(record[3].get("longValue", 0))
-        
+
         if athlete_id and access_token and refresh_token:
             users.append({
                 "athlete_id": athlete_id,
@@ -384,54 +397,51 @@ def get_all_connected_users():
                 "refresh_token": refresh_token,
                 "expires_at": expires_at
             })
-    
+
     return users
 
 
-def update_recent_activities_for_user(user):
-    """Update recent activities for a single user"""
+def update_recent_activities_for_user(user, context=None):
+    """Update recent activities for a single user.
+
+    The per-user `/athlete` profile call has been removed: it doubled the
+    rate-limit budget for no functional benefit (profile pics are not
+    time-sensitive). Re-add it as a separate, less-frequent job if needed.
+    """
     athlete_id = user["athlete_id"]
     access_token = user["access_token"]
     refresh_token = user["refresh_token"]
     expires_at = user["expires_at"]
-    
+
     try:
         log(f"Processing user {athlete_id}...", "INFO")
-        
+
         # Ensure token is valid
         access_token = ensure_valid_token(athlete_id, access_token, refresh_token, expires_at)
-        
-        # Refresh profile picture in case the athlete updated their avatar (best-effort)
-        try:
-            athlete_profile = fetch_strava_athlete(access_token)
-            if athlete_profile:
-                update_user_profile_picture(athlete_id, athlete_profile)
-        except Exception as profile_err:
-            log(f"Skipping profile update for athlete {athlete_id} due to error: {profile_err}", "WARNING")
-        
+
         # Calculate timestamp for 24 hours ago
         current_time = int(time.time())
         after_timestamp = max(ACTIVITIES_START_DATE, current_time - UPDATE_WINDOW_SECONDS)
-        
+
         # Fetch recent activities
-        activities = fetch_strava_activities(access_token, after_timestamp)
-        
+        activities = fetch_strava_activities(access_token, after_timestamp, context=context)
+
         if not isinstance(activities, list):
             log(f"Unexpected response from Strava API for user {athlete_id}: {type(activities)}", "ERROR")
             return {"athlete_id": athlete_id, "success": False, "error": "Invalid API response"}
-        
+
         # Store activities
         stored_count = 0
         failed_count = 0
-        
+
         for activity in activities:
             if store_activity(athlete_id, activity):
                 stored_count += 1
             else:
                 failed_count += 1
-        
+
         log(f"User {athlete_id}: Stored {stored_count}, Failed {failed_count} out of {len(activities)} activities", "INFO")
-        
+
         return {
             "athlete_id": athlete_id,
             "success": True,
@@ -439,7 +449,10 @@ def update_recent_activities_for_user(user):
             "stored": stored_count,
             "failed": failed_count
         }
-        
+
+    except RateLimitExhaustedError:
+        # Bubble up so the handler can stop processing and self-continue.
+        raise
     except Exception as e:
         log(f"Processing user {athlete_id}: {e}", "ERROR")
         import traceback
@@ -447,11 +460,40 @@ def update_recent_activities_for_user(user):
         return {"athlete_id": athlete_id, "success": False, "error": str(e)}
 
 
+def _self_continue(context, remaining_athlete_ids):
+    """Re-invoke this Lambda asynchronously to process the remaining users.
+
+    Avoids running every connected user in a single invocation: bounded batches
+    keep us comfortably inside Lambda's 15-minute hard cap and isolate the
+    blast radius of one slow user.
+    """
+    function_name = (context.function_name if context else None) or os.environ.get("AWS_LAMBDA_FUNCTION_NAME")
+    if not function_name:
+        log("Cannot self-continue: function name unknown", "WARNING")
+        return False
+    try:
+        lambda_client.invoke(
+            FunctionName=function_name,
+            InvocationType="Event",
+            Payload=json.dumps({"continue_athlete_ids": remaining_athlete_ids}).encode(),
+        )
+        log(f"Self-invoked to continue with {len(remaining_athlete_ids)} remaining users", "INFO")
+        return True
+    except Exception as e:
+        log(f"Failed to self-continue ({e}); next scheduled run will pick them up", "WARNING")
+        return False
+
+
 def handler(event, context):
     """
     Lambda handler for scheduled activity updates.
-    
-    Runs every hour to update activities from the last 24 hours for all connected users.
+
+    Runs every hour as a backstop for missed webhooks. Two execution modes:
+      1. Scheduled invoke (no `continue_athlete_ids` in event): pulls connected
+         users that webhooks have not kept fresh recently, processes the first
+         USERS_PER_INVOCATION, and self-invokes for the rest.
+      2. Continuation invoke (`continue_athlete_ids` in event): processes only
+         the supplied athlete IDs and self-invokes again if needed.
     """
     start_time = datetime.utcnow()
     log(SEPARATOR_LINE, "INFO")
@@ -459,104 +501,106 @@ def handler(event, context):
     log(f"Execution started at: {start_time.isoformat()}Z", "INFO")
     log(f"Event: {json.dumps(event, default=str)}", "INFO")
     log(SEPARATOR_LINE, "INFO")
-    
-    # Get environment variables
-    db_cluster_arn = os.environ.get("DB_CLUSTER_ARN", "")
-    db_secret_arn = os.environ.get("DB_SECRET_ARN", "")
-    
-    # Validate required environment variables
-    if not db_cluster_arn or not db_secret_arn:
+
+    if not os.environ.get("DB_CLUSTER_ARN") or not os.environ.get("DB_SECRET_ARN"):
         log("Missing DB_CLUSTER_ARN or DB_SECRET_ARN", "ERROR")
-        log("SCHEDULED ACTIVITY UPDATE - FAILED (Configuration Error)", "ERROR")
         return {
             "statusCode": 500,
             "body": json.dumps({"error": "server configuration error"})
         }
-    
+
     try:
-        # Get all connected users
-        log("Fetching all connected users...", "INFO")
-        users = get_all_connected_users()
-        log(f"Found {len(users)} connected users", "INFO")
-        
+        continue_ids = event.get("continue_athlete_ids") if isinstance(event, dict) else None
+        if continue_ids:
+            log(f"Continuation invocation: {len(continue_ids)} athlete IDs", "INFO")
+            all_users = get_users_needing_poll()
+            id_set = set(continue_ids)
+            users = [u for u in all_users if u["athlete_id"] in id_set]
+            log(f"Resolved {len(users)} of {len(continue_ids)} continuation IDs to active users", "INFO")
+        else:
+            log("Fetching connected users that webhooks have not kept fresh...", "INFO")
+            users = get_users_needing_poll()
+            log(f"Found {len(users)} users to poll (webhook-stale or never-webhooked)", "INFO")
+
         if not users:
-            log("No connected users found, nothing to update", "INFO")
             end_time = datetime.utcnow()
             duration = (end_time - start_time).total_seconds()
-            log(SEPARATOR_LINE, "INFO")
-            log(f"SCHEDULED ACTIVITY UPDATE - SUCCESS (No Users)", "INFO")
-            log(f"Execution completed at: {end_time.isoformat()}Z", "INFO")
-            log(f"Duration: {duration:.2f} seconds", "INFO")
-            log(SEPARATOR_LINE, "INFO")
+            log(f"SCHEDULED ACTIVITY UPDATE - SUCCESS (No Users), duration {duration:.1f}s", "INFO")
             return {
                 "statusCode": 200,
-                "body": json.dumps({
-                    "message": "No connected users found",
-                    "total_users": 0,
-                    "results": []
-                })
+                "body": json.dumps({"message": "No users to poll", "total_users": 0, "results": []})
             }
-        
-        # Update activities for each user
-        log("Starting activity updates for all users...", "INFO")
+
+        # Process this chunk; defer the rest to a continuation invocation.
+        chunk = users[:USERS_PER_INVOCATION]
+        remaining_ids = [u["athlete_id"] for u in users[USERS_PER_INVOCATION:]]
+
         results = []
-        for user in users:
-            result = update_recent_activities_for_user(user)
-            results.append(result)
+        aborted_early = False
+        for user in chunk:
+            # Time-budget guard: leave headroom for the self-continue invocation.
+            remaining_ms = _seconds_until_lambda_deadline(context)
+            if remaining_ms < LAMBDA_TIME_REMAINING_SAFETY_MS:
+                log(f"Lambda time budget exhausted ({remaining_ms/1000:.0f}s remaining); aborting chunk early", "WARNING")
+                # Push unprocessed chunk users back onto the continuation list.
+                idx = chunk.index(user)
+                remaining_ids = [u["athlete_id"] for u in chunk[idx:]] + remaining_ids
+                aborted_early = True
+                break
+
+            try:
+                results.append(update_recent_activities_for_user(user, context=context))
+            except RateLimitExhaustedError:
+                log("Rate limit exhausted; aborting chunk and deferring rest to next scheduled run", "WARNING")
+                idx = chunk.index(user)
+                remaining_ids = [u["athlete_id"] for u in chunk[idx:]] + remaining_ids
+                aborted_early = True
+                break
+
             time.sleep(1)  # pace requests to avoid rate limit burst
-        
-        # Summary
-        successful_updates = sum(1 for r in results if r.get("success"))
-        failed_updates = len(results) - successful_updates
-        total_activities_stored = sum(r.get("stored", 0) for r in results)
-        
-        summary = {
-            "message": "Scheduled activity update completed",
-            "total_users": len(users),
-            "successful_updates": successful_updates,
-            "failed_updates": failed_updates,
-            "total_activities_stored": total_activities_stored,
-            "results": results
-        }
-        
+
+        if remaining_ids and not aborted_early:
+            _self_continue(context, remaining_ids)
+        elif remaining_ids and aborted_early:
+            # Don't immediately self-invoke after a rate-limit/time abort —
+            # let the next scheduled run pick it up after the window resets.
+            log(f"{len(remaining_ids)} users deferred to next scheduled run", "INFO")
+
+        successful = sum(1 for r in results if r.get("success"))
+        failed = len(results) - successful
+        total_stored = sum(r.get("stored", 0) for r in results)
+
         end_time = datetime.utcnow()
         duration = (end_time - start_time).total_seconds()
-        
-        # Log summary
+
         log(SEPARATOR_LINE, "INFO")
         log("EXECUTION SUMMARY:", "INFO")
-        log(f"  Total users processed: {len(users)}", "INFO")
-        log(f"  Successful updates: {successful_updates}", "INFO")
-        log(f"  Failed updates: {failed_updates}", "INFO")
-        log(f"  Total activities stored: {total_activities_stored}", "INFO")
-        log(f"  Rate limit usage at end of run: {_rate_limit_used}/{_rate_limit_limit}", "INFO")
+        log(f"  Users processed this invocation: {len(results)}", "INFO")
+        log(f"  Users deferred to continuation: {len(remaining_ids)}", "INFO")
+        log(f"  Successful: {successful}", "INFO")
+        log(f"  Failed: {failed}", "INFO")
+        log(f"  Activities stored: {total_stored}", "INFO")
+        log(f"  Rate limit usage: {_rate_limit_used}/{_rate_limit_limit}", "INFO")
+        log(f"  Duration: {duration:.2f}s", "INFO")
         log(SEPARATOR_LINE, "INFO")
-        
-        status = "SUCCESS" if failed_updates == 0 else "PARTIAL SUCCESS"
-        log(f"SCHEDULED ACTIVITY UPDATE - {status}", "INFO")
-        log(f"Execution completed at: {end_time.isoformat()}Z", "INFO")
-        log(f"Duration: {duration:.2f} seconds", "INFO")
-        log(SEPARATOR_LINE, "INFO")
-        
+
         return {
             "statusCode": 200,
-            "body": json.dumps(summary)
+            "body": json.dumps({
+                "message": "Scheduled activity update completed",
+                "users_processed": len(results),
+                "users_deferred": len(remaining_ids),
+                "successful_updates": successful,
+                "failed_updates": failed,
+                "total_activities_stored": total_stored,
+                "results": results,
+            })
         }
-        
+
     except Exception as e:
-        end_time = datetime.utcnow()
-        duration = (end_time - start_time).total_seconds()
-        
-        log(SEPARATOR_LINE, "ERROR")
         log(f"Error in scheduled_activity_update handler: {e}", "ERROR")
         import traceback
         traceback.print_exc()
-        log(SEPARATOR_LINE, "ERROR")
-        log("SCHEDULED ACTIVITY UPDATE - FAILED", "ERROR")
-        log(f"Execution completed at: {end_time.isoformat()}Z", "ERROR")
-        log(f"Duration: {duration:.2f} seconds", "ERROR")
-        log(SEPARATOR_LINE, "ERROR")
-        
         return {
             "statusCode": 500,
             "body": json.dumps({"error": "internal server error", "details": str(e)})

--- a/backend/webhook_processor/lambda_function.py
+++ b/backend/webhook_processor/lambda_function.py
@@ -19,12 +19,20 @@ import json
 import time
 from datetime import datetime, timezone, timedelta
 from urllib.request import Request, urlopen
+from urllib.error import HTTPError
 from urllib.parse import urlencode
 import boto3
 
 rds = boto3.client("rds-data")
 sm = boto3.client("secretsmanager")
 lambda_client = boto3.client("lambda")
+sqs = boto3.client("sqs")
+
+# Default visibility-timeout extension when Strava returns 429 with no Retry-After.
+# 15 minutes is one full Strava rate-limit window.
+DEFAULT_RATE_LIMIT_DEFER_SECONDS = 15 * 60
+# SQS caps per-message visibility-timeout extensions at 12 hours.
+MAX_VISIBILITY_TIMEOUT_SECONDS = 12 * 60 * 60
 
 # Get environment variables
 DB_CLUSTER_ARN = os.environ.get("DB_CLUSTER_ARN", "")
@@ -37,6 +45,13 @@ STRAVA_ACTIVITY_URL = "https://www.strava.com/api/v3/activities"
 
 # Token refresh buffer - refresh tokens 5 minutes before expiry
 TOKEN_REFRESH_BUFFER_SECONDS = 300
+
+
+class StravaRateLimitError(Exception):
+    """Raised when Strava returns 429 and we want SQS to retry the message later."""
+    def __init__(self, retry_after_seconds=None):
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__(f"Strava rate limit hit (retry_after={retry_after_seconds}s)")
 
 
 def _get_strava_creds():
@@ -134,26 +149,43 @@ def get_user_tokens(athlete_id):
     return access_token, refresh_token, expires_at
 
 
+def _parse_retry_after(retry_after_header):
+    """Parse Retry-After header value (seconds-only) into an int. Returns None on failure."""
+    if not retry_after_header:
+        return None
+    try:
+        return max(0, int(retry_after_header))
+    except (TypeError, ValueError):
+        return None
+
+
 def fetch_activity_details(access_token, activity_id):
-    """Fetch detailed activity data from Strava API"""
+    """Fetch detailed activity data from Strava API.
+
+    On HTTP 429 we surface a StravaRateLimitError so the caller can defer the
+    SQS message instead of letting it cycle through retries and land in the DLQ.
+    """
     url = f"{STRAVA_ACTIVITY_URL}/{activity_id}"
     req = Request(url, headers={"Authorization": f"Bearer {access_token}"})
-    
+
     try:
         with urlopen(req, timeout=30) as resp:
             activity = json.loads(resp.read().decode())
         print(f"Fetched activity {activity_id} from Strava API")
         return activity
+    except HTTPError as e:
+        print(f"Failed to fetch activity {activity_id} from Strava: HTTP {e.code}")
+        try:
+            error_body = e.read().decode()
+            print(f"Error response body: {error_body}")
+        except Exception:
+            pass
+        if e.code == 429:
+            retry_after = _parse_retry_after(e.headers.get("Retry-After") if e.headers else None)
+            raise StravaRateLimitError(retry_after_seconds=retry_after) from e
+        raise
     except Exception as e:
         print(f"Failed to fetch activity {activity_id} from Strava: {e}")
-        if hasattr(e, 'code'):
-            print(f"HTTP status code: {e.code}")
-        if hasattr(e, 'read'):
-            try:
-                error_body = e.read().decode()
-                print(f"Error response body: {error_body}")
-            except Exception:
-                pass
         raise
 
 
@@ -534,34 +566,54 @@ def mark_event_processed(idempotency_key, webhook_event):
         print(f"WARNING: Failed to mark event as processed (table may not exist): {e}")
 
 
+def update_last_webhook_received(athlete_id):
+    """Record that we just successfully processed a webhook event for this athlete.
+
+    Used by the hourly scheduled_activity_update job to skip users whose data
+    is already being kept fresh by webhooks.
+    """
+    sql = "UPDATE users SET last_webhook_received_at = now() WHERE athlete_id = :aid"
+    params = [{"name": "aid", "value": {"longValue": athlete_id}}]
+    try:
+        _exec_sql(sql, params)
+    except Exception as e:
+        # Non-fatal: column may not exist yet (pre-migration). Do not fail the event.
+        print(f"WARNING: Failed to update last_webhook_received_at for {athlete_id}: {e}")
+
+
 def process_webhook_event(webhook_event):
-    """Process a single webhook event"""
+    """Process a single webhook event.
+
+    Returns True on success, False on retryable failure. Raises
+    StravaRateLimitError when we want the caller to defer the SQS message
+    rather than rely on normal retry/DLQ behavior.
+    """
     object_type = webhook_event.get("object_type")
     aspect_type = webhook_event.get("aspect_type")
     object_id = int(webhook_event.get("object_id", 0))
     owner_id = int(webhook_event.get("owner_id", 0))
     subscription_id = webhook_event.get("subscription_id")
     event_time = webhook_event.get("event_time")
-    
+
     print(f"Processing webhook event: {object_type} {aspect_type} {object_id} for athlete {owner_id}")
-    
+
     # Create idempotency key
     idempotency_key = f"{subscription_id}:{object_id}:{aspect_type}:{event_time}"
-    
+
     # Check if already processed
     if check_idempotency(idempotency_key):
         print(f"Event already processed: {idempotency_key}")
         return True
-    
+
     # Get user tokens
     access_token, refresh_token, expires_at = get_user_tokens(owner_id)
-    
+
     if not access_token or not refresh_token:
         print(f"User {owner_id} not found or not connected to Strava")
         # Mark as processed to avoid retrying
         mark_event_processed(idempotency_key, webhook_event)
         return True
-    
+
     # Check if token needs refresh
     current_time = int(time.time())
     if expires_at < current_time + TOKEN_REFRESH_BUFFER_SECONDS:
@@ -572,11 +624,11 @@ def process_webhook_event(webhook_event):
             print(f"ERROR: Token refresh failed: {e}")
             # Don't mark as processed, allow retry
             return False
-    
+
     # Handle different event types
     success = False
     activity_id = None
-    
+
     if aspect_type == "delete":
         # Delete from leaderboard aggregates first (before deleting activity record)
         delete_leaderboard_aggregates(owner_id, object_id)
@@ -588,14 +640,18 @@ def process_webhook_event(webhook_event):
             activity = fetch_activity_details(access_token, object_id)
             activity_id = store_activity(owner_id, activity)
             success = activity_id is not None
-            
+
             # Update leaderboard aggregates for the activity
             if success:
                 update_leaderboard_aggregates(owner_id, activity)
-            
+
             # Trigger trail matching for the activity
             if success and activity_id:
                 trigger_trail_matching(activity_id)
+        except StravaRateLimitError:
+            # Bubble up so the SQS handler can defer the message rather than
+            # letting it churn through retries and end up in the DLQ.
+            raise
         except Exception as e:
             print(f"ERROR: Failed to fetch/store activity: {e}")
             # Don't mark as processed if fetch failed (might be temporary)
@@ -603,61 +659,104 @@ def process_webhook_event(webhook_event):
     else:
         print(f"Unknown aspect_type: {aspect_type}")
         success = True  # Mark as processed to avoid retrying unknown types
-    
+
     # Mark event as processed
     if success:
         mark_event_processed(idempotency_key, webhook_event)
-    
+        update_last_webhook_received(owner_id)
+
     return success
+
+
+def _defer_message_for_rate_limit(record, retry_after_seconds):
+    """Extend the SQS visibility timeout for a single message so it isn't redelivered
+    while we're still rate-limited. Falls back to letting SQS handle retry naturally
+    if the API call fails (e.g. permissions issue)."""
+    queue_arn = record.get("eventSourceARN")
+    receipt_handle = record.get("receiptHandle")
+    if not queue_arn or not receipt_handle:
+        return False
+
+    # Convert ARN -> URL: arn:aws:sqs:region:account:queue-name
+    parts = queue_arn.split(":")
+    if len(parts) < 6:
+        return False
+    region, account, queue_name = parts[3], parts[4], parts[5]
+    queue_url = f"https://sqs.{region}.amazonaws.com/{account}/{queue_name}"
+
+    timeout = retry_after_seconds or DEFAULT_RATE_LIMIT_DEFER_SECONDS
+    timeout = max(60, min(timeout, MAX_VISIBILITY_TIMEOUT_SECONDS))
+
+    try:
+        sqs.change_message_visibility(
+            QueueUrl=queue_url,
+            ReceiptHandle=receipt_handle,
+            VisibilityTimeout=timeout,
+        )
+        print(f"Deferred message {record.get('messageId')} for {timeout}s due to Strava 429")
+        return True
+    except Exception as e:
+        print(f"WARNING: change_message_visibility failed for {record.get('messageId')}: {e}")
+        return False
 
 
 def handler(event, context):
     """
     Lambda handler triggered by SQS.
     Processes webhook events from the queue.
+
+    Uses partial-batch failure reporting (ReportBatchItemFailures) so a single
+    bad message doesn't recycle the entire batch. Requires the event source
+    mapping to have FunctionResponseTypes=["ReportBatchItemFailures"] enabled.
     """
     print(f"webhook_processor handler invoked")
-    print(f"Event: {json.dumps(event, default=str)}")
-    
+
     # Validate required environment variables
     if not DB_CLUSTER_ARN or not DB_SECRET_ARN:
         print("ERROR: Missing DB_CLUSTER_ARN or DB_SECRET_ARN")
         raise RuntimeError("Missing database configuration")
-    
-    # Process each SQS record
+
     records = event.get("Records", [])
     print(f"Processing {len(records)} SQS records")
-    
-    failed_records = []
-    
+
+    batch_item_failures = []
+    rate_limited = False
+
     for record in records:
+        message_id = record.get("messageId")
         try:
-            # Parse webhook event from SQS message
             message_body = record.get("body", "{}")
             webhook_event = json.loads(message_body)
-            
-            print(f"Processing SQS record: {record.get('messageId')}")
-            
-            # Process the event
+
+            print(f"Processing SQS record: {message_id}")
+
+            if rate_limited:
+                # We've already hit the rate limit on this batch; don't burn more
+                # of the budget. Defer the rest and let them retry later.
+                _defer_message_for_rate_limit(record, None)
+                batch_item_failures.append({"itemIdentifier": message_id})
+                continue
+
             success = process_webhook_event(webhook_event)
-            
+
             if not success:
                 print(f"Failed to process event: {webhook_event}")
-                failed_records.append(record)
+                batch_item_failures.append({"itemIdentifier": message_id})
+        except StravaRateLimitError as rle:
+            # Bound the retry window so we don't burn the SQS receive count
+            # while Strava is throttling us. Defer this message and every
+            # remaining message in the batch.
+            print(f"Strava rate-limited; deferring {message_id} (retry_after={rle.retry_after_seconds})")
+            _defer_message_for_rate_limit(record, rle.retry_after_seconds)
+            batch_item_failures.append({"itemIdentifier": message_id})
+            rate_limited = True
         except Exception as e:
-            print(f"ERROR processing SQS record: {e}")
+            print(f"ERROR processing SQS record {message_id}: {e}")
             import traceback
             traceback.print_exc()
-            failed_records.append(record)
-    
-    # If any records failed, raise an exception to trigger retry
-    if failed_records:
-        print(f"{len(failed_records)} records failed processing")
-        # SQS will retry based on queue configuration
-        raise RuntimeError(f"Failed to process {len(failed_records)} records")
-    
-    print(f"Successfully processed all {len(records)} records")
-    return {
-        "statusCode": 200,
-        "body": json.dumps({"processed": len(records)})
-    }
+            batch_item_failures.append({"itemIdentifier": message_id})
+
+    if batch_item_failures:
+        print(f"{len(batch_item_failures)} of {len(records)} records failed; reporting partial batch failure")
+
+    return {"batchItemFailures": batch_item_failures}


### PR DESCRIPTION
## Summary
- Drop the per-user `/athlete` profile call from `scheduled_activity_update` and skip users that webhooks have already kept fresh (new `users.last_webhook_received_at`, populated by `webhook_processor`).
- Shard the hourly job: at most 25 users per invocation, then self-invoke async to continue. Bound rate-limit waits by remaining Lambda time so one bad user can't time out the batch.
- `webhook_processor` now honors HTTP 429 from `/activities/{id}` (parses `Retry-After`), uses partial-batch failure reporting, and extends SQS visibility timeout instead of cycling messages into the DLQ during throttling.

## Why
API usage graphs showed a steady ~33 reads/15min floor running 24/7 — entirely from the hourly poll calling `/athlete` + `/athlete/activities` for every connected user. That alone exceeds the 3,000/day Read limit and starves webhook traffic during US-evening upload spikes. When webhooks then 429'd, the processor had no rate-limit handling and uploads silently DLQ'd.

## Deployment notes (manual, outside this PR)
- Run migration `011_add_last_webhook_received.sql`.
- Set `FunctionResponseTypes=["ReportBatchItemFailures"]` on the `webhook_processor` SQS event source mapping.
- Grant `webhook_processor` IAM role `sqs:ChangeMessageVisibility` on the webhook queue.
- Grant `scheduled_activity_update` IAM role `lambda:InvokeFunction` on itself (for self-continuation).

The new query falls back to "all connected users" if the column is missing, so the lambda and migration can deploy in either order.

## Test plan
- [ ] Verify `webhook_processor` Lambda still processes a real Strava activity create event end-to-end after the SQS event source mapping is updated.
- [ ] Trigger a manual `scheduled_activity_update` invocation and confirm logs show `users_processed` ≤ 25 and a continuation invocation when more users are pending.
- [ ] Check Strava API Usage dashboard 24h after deploy: daily Read count should drop substantially below the 3,000 cap.
- [ ] Force a 429 on `webhook_processor` (e.g. by replaying a burst) and confirm messages get deferred via `ChangeMessageVisibility` instead of landing in the DLQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)