### PR TITLE
Fix leaderboard double-count by recomputing aggregates set-based

### DIFF
--- a/.github/workflows/deploy-lambdas.yml
+++ b/.github/workflows/deploy-lambdas.yml
@@ -37,6 +37,8 @@ jobs:
             secret: LAMBDA_WEBHOOK
           - name: webhook_processor
             secret: LAMBDA_WEBHOOK_PROCESSOR
+            needs_timezone_utils: true
+            needs_leaderboard_agg: true
           - name: reset_last_matched
             secret: LAMBDA_RESET_LAST_MATCHED
           - name: update_trail_data
@@ -45,6 +47,8 @@ jobs:
             secret: LAMBDA_UPDATE_ACTIVITIES
           - name: match_activity_trail
             secret: LAMBDA_MATCH_ACTIVITY_TRAIL
+            needs_timezone_utils: true
+            needs_leaderboard_agg: true
           - name: match_unmatched_activities
             secret: LAMBDA_MATCH_UNMATCHED_ACTIVITIES
           - name: admin_list_users
@@ -109,6 +113,10 @@ jobs:
           # Include timezone_utils.py for Lambdas that need timezone handling
           if [ "${{ matrix.lambda.needs_timezone_utils }}" = "true" ]; then
             zip -j function.zip ../timezone_utils.py
+          fi
+          # Include leaderboard_agg.py for Lambdas that recompute leaderboards
+          if [ "${{ matrix.lambda.needs_leaderboard_agg }}" = "true" ]; then
+            zip -j function.zip ../leaderboard_agg.py
           fi
 
       - name: Deploy ${{ matrix.lambda.name }} Lambda

--- a/backend/leaderboard_agg.py
+++ b/backend/leaderboard_agg.py
@@ -1,0 +1,180 @@
+"""
+Shared leaderboard aggregation helpers for RabbitMiles.
+
+The leaderboard_agg table is recomputed set-based from activities after each
+match or activity delete. This avoids the read-modify-write race that the
+incremental delta approach had (two concurrent matchers both reading
+old_distance_on_trail=0 and double-counting).
+
+Public surface:
+- get_aggregate_types(activity_type)
+- get_window_bounds(start_date_local, user_timezone, activity_timezone)
+- is_opted_in(exec_sql, athlete_id)
+- recompute_for_activity(exec_sql, athlete_id, start_date_local, user_timezone, activity_timezone)
+"""
+
+from datetime import datetime, timedelta
+
+import timezone_utils
+
+
+METRIC = "distance"
+
+# Activity-type buckets the leaderboard aggregates against. We always recompute
+# all three so that an activity whose type was edited (e.g. Run -> Ride on
+# Strava) doesn't leave a stale value in the old bucket.
+ALL_AGG_TYPES = ("all", "foot", "bike")
+
+# Activity.type values that count toward each bucket. "all" has no filter.
+TYPE_FILTER_SQL = {
+    "all": "",
+    "foot": "AND type IN ('Run', 'Walk')",
+    "bike": "AND type = 'Ride'",
+}
+
+
+def get_aggregate_types(activity_type):
+    """Return the leaderboard buckets a single activity contributes to.
+
+    Kept for callers that still want the pre-recompute "this one activity
+    affects buckets X" view. The recompute path uses ALL_AGG_TYPES instead.
+    """
+    types = ["all"]
+    if activity_type in ("Run", "Walk"):
+        types.append("foot")
+    elif activity_type == "Ride":
+        types.append("bike")
+    return types
+
+
+def get_window_bounds(start_date_local, user_timezone=None, activity_timezone=None):
+    """Compute (window_key, start_dt, end_dt) for an activity's week/month/year.
+
+    Returns dict keyed by 'week'/'month'/'year' with tuples of
+    (window_key, start_datetime_naive, end_datetime_naive). The datetimes are
+    naive timestamps in the user's local timezone, matching how
+    activities.start_date_local is stored.
+
+    Returns None on parse failure so the caller can decide to skip rather
+    than crash the match.
+    """
+    try:
+        dt_str = start_date_local.replace("Z", "+00:00") if isinstance(start_date_local, str) else None
+        if dt_str is None:
+            return None
+        dt = datetime.fromisoformat(dt_str)
+    except (ValueError, TypeError) as e:
+        print(f"ERROR: Failed to parse activity date {start_date_local!r}: {e}")
+        return None
+
+    tz = timezone_utils.get_user_timezone(user_timezone, activity_timezone)
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(tz).replace(tzinfo=None)
+
+    # Week: Monday 00:00 inclusive, next Monday 00:00 exclusive
+    days_since_monday = dt.weekday()
+    week_start = dt.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=days_since_monday)
+    week_end = week_start + timedelta(days=7)
+    week_key = f"week_{week_start.strftime('%Y-%m-%d')}"
+
+    # Month: 1st 00:00 inclusive, next month's 1st 00:00 exclusive
+    month_start = dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if month_start.month == 12:
+        month_end = month_start.replace(year=month_start.year + 1, month=1)
+    else:
+        month_end = month_start.replace(month=month_start.month + 1)
+    month_key = f"month_{dt.strftime('%Y-%m')}"
+
+    # Year: Jan 1 00:00 inclusive, next year's Jan 1 00:00 exclusive
+    year_start = dt.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+    year_end = year_start.replace(year=year_start.year + 1)
+    year_key = f"year_{dt.strftime('%Y')}"
+
+    return {
+        "week": (week_key, week_start, week_end),
+        "month": (month_key, month_start, month_end),
+        "year": (year_key, year_start, year_end),
+    }
+
+
+def is_opted_in(exec_sql, athlete_id):
+    """Return True if the user has show_on_leaderboards = true."""
+    sql = "SELECT show_on_leaderboards FROM users WHERE athlete_id = :aid"
+    params = [{"name": "aid", "value": {"longValue": int(athlete_id)}}]
+    try:
+        result = exec_sql(sql, params)
+    except Exception as e:
+        print(f"ERROR: Failed to check leaderboard opt-in for {athlete_id}: {e}")
+        return False
+
+    records = result.get("records", [])
+    if not records:
+        return False
+    field = records[0][0]
+    if "booleanValue" in field:
+        return bool(field["booleanValue"])
+    if "stringValue" in field:
+        return field["stringValue"].lower() in ("true", "t", "1")
+    return False
+
+
+def _recompute_one(exec_sql, athlete_id, window_name, window_key, start_dt, end_dt, agg_type):
+    """Issue one INSERT…SELECT SUM…ON CONFLICT DO UPDATE for a single bucket."""
+    type_filter = TYPE_FILTER_SQL[agg_type]
+    sql = f"""
+    INSERT INTO leaderboard_agg ("window", window_key, metric, activity_type, athlete_id, value, last_updated)
+    SELECT :window, :window_key, :metric, :act_type, :aid,
+           COALESCE(SUM(distance_on_trail), 0), now()
+      FROM activities
+     WHERE athlete_id = :aid
+       AND start_date_local >= CAST(:start_dt AS TIMESTAMP)
+       AND start_date_local <  CAST(:end_dt AS TIMESTAMP)
+       AND distance_on_trail IS NOT NULL
+       {type_filter}
+    ON CONFLICT (window_key, metric, activity_type, athlete_id)
+    DO UPDATE SET value = EXCLUDED.value, last_updated = now()
+    """
+    params = [
+        {"name": "window", "value": {"stringValue": window_name}},
+        {"name": "window_key", "value": {"stringValue": window_key}},
+        {"name": "metric", "value": {"stringValue": METRIC}},
+        {"name": "act_type", "value": {"stringValue": agg_type}},
+        {"name": "aid", "value": {"longValue": int(athlete_id)}},
+        {"name": "start_dt", "value": {"stringValue": start_dt.isoformat()}},
+        {"name": "end_dt", "value": {"stringValue": end_dt.isoformat()}},
+    ]
+    exec_sql(sql, params)
+
+
+def recompute_for_activity(exec_sql, athlete_id, start_date_local,
+                           user_timezone=None, activity_timezone=None):
+    """Recompute leaderboard_agg for the user's three windows × three buckets.
+
+    The current value of every bucket is overwritten with COALESCE(SUM, 0)
+    from activities — no incremental math, so concurrent invocations converge
+    to the same result.
+
+    No-op if the user is opted out. Returns True on success, False on
+    irrecoverable failure (per-bucket failures are logged but don't abort
+    the rest of the recompute).
+    """
+    if not is_opted_in(exec_sql, athlete_id):
+        return True
+
+    bounds = get_window_bounds(start_date_local, user_timezone, activity_timezone)
+    if not bounds:
+        print(f"ERROR: Could not compute window bounds for athlete {athlete_id} date {start_date_local!r}")
+        return False
+
+    ok = True
+    for window_name, (window_key, start_dt, end_dt) in bounds.items():
+        for agg_type in ALL_AGG_TYPES:
+            try:
+                _recompute_one(exec_sql, athlete_id, window_name, window_key, start_dt, end_dt, agg_type)
+            except Exception as e:
+                ok = False
+                print(
+                    f"ERROR: Failed to recompute leaderboard_agg for athlete={athlete_id} "
+                    f"window={window_key} type={agg_type}: {e}"
+                )
+    return ok

--- a/backend/match_activity_trail/lambda_function.py
+++ b/backend/match_activity_trail/lambda_function.py
@@ -10,9 +10,16 @@
 # TRAIL_DATA_BUCKET (e.g., rabbitmiles-trail-data)
 
 import os
+import sys
 import json
 import boto3
-from datetime import datetime, timedelta
+from datetime import datetime
+
+# Add parent directory to path to import shared modules
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+
+import leaderboard_agg
 
 rds = boto3.client("rds-data")
 s3 = boto3.client("s3")
@@ -358,34 +365,37 @@ def calculate_trail_intersection(activity_coords, trail_segments, tolerance_mete
 
 
 def get_activity_from_db(activity_id):
-    """Fetch activity details from database"""
+    """Fetch activity details from database.
+
+    Returns the metadata `leaderboard_agg.recompute_for_activity` needs
+    (start_date_local, activity timezone, user timezone) so the post-match
+    leaderboard recompute can run without an extra round-trip.
+    """
     sql = """
-    SELECT athlete_id, strava_activity_id, polyline, moving_time, distance, COALESCE(distance_on_trail, 0) as distance_on_trail
-    FROM activities
-    WHERE id = :id
+    SELECT a.athlete_id, a.strava_activity_id, a.polyline, a.moving_time, a.distance,
+           a.start_date_local, a.timezone AS activity_timezone, u.timezone AS user_timezone
+      FROM activities a
+      LEFT JOIN users u ON u.athlete_id = a.athlete_id
+     WHERE a.id = :id
     """
     params = [{"name": "id", "value": {"longValue": activity_id}}]
-    
+
     result = _exec_sql(sql, params)
     records = result.get("records", [])
-    
+
     if not records:
         return None
-    
+
     record = records[0]
-    
+
     # Handle DECIMAL fields that come back as stringValue
     distance_str = record[4].get("stringValue")
     distance = float(distance_str) if distance_str else 0.0
-    
-    distance_on_trail_field = record[5]
-    if "doubleValue" in distance_on_trail_field:
-        old_distance_on_trail = float(distance_on_trail_field["doubleValue"])
-    elif "stringValue" in distance_on_trail_field:
-        old_distance_on_trail = float(distance_on_trail_field["stringValue"])
-    else:
-        old_distance_on_trail = 0.0
-    
+
+    start_date_local = record[5].get("stringValue") if not record[5].get("isNull") else ""
+    activity_timezone = record[6].get("stringValue") if not record[6].get("isNull") else None
+    user_timezone = record[7].get("stringValue") if not record[7].get("isNull") else None
+
     return {
         "activity_id": activity_id,
         "athlete_id": int(record[0].get("longValue", 0)),
@@ -393,7 +403,9 @@ def get_activity_from_db(activity_id):
         "polyline": record[2].get("stringValue", ""),
         "moving_time": int(record[3].get("longValue", 0)),
         "distance": distance,
-        "old_distance_on_trail": old_distance_on_trail
+        "start_date_local": start_date_local,
+        "activity_timezone": activity_timezone,
+        "user_timezone": user_timezone,
     }
 
 
@@ -418,204 +430,101 @@ def update_activity_trail_metrics(activity_id, distance_on_trail, time_on_trail)
     print(f"Updated activity {activity_id} with trail metrics")
 
 
-def get_window_keys(start_date_local):
-    """
-    Calculate window keys (week, month, year) for an activity based on its start date.
-    
-    Args:
-        start_date_local: ISO 8601 timestamp string (e.g., "2026-02-15T10:30:00Z")
-    
-    Returns:
-        Dict with 'week', 'month', 'year' keys containing window_key strings
+def update_leaderboard_after_trail_matching(athlete_id, start_date_local,
+                                             user_timezone=None, activity_timezone=None):
+    """Recompute leaderboard_agg for the user's three windows from `activities`.
+
+    Set-based and idempotent: concurrent matchers converge to the same totals,
+    so we no longer leak +distance per racing webhook.
     """
     try:
-        # Parse ISO 8601 timestamp (can be with or without timezone)
-        dt_str = start_date_local.replace('Z', '+00:00')
-        if '+' not in dt_str and dt_str.count(':') == 2:
-            # No timezone info, assume UTC
-            dt = datetime.fromisoformat(dt_str)
-        else:
-            dt = datetime.fromisoformat(dt_str)
-        
-        # Week: ISO week format, Monday is start of week
-        # Window key format: week_YYYY-MM-DD (Monday of the week)
-        days_since_monday = dt.weekday()  # Monday is 0
-        monday = dt.replace(hour=0, minute=0, second=0, microsecond=0)
-        if days_since_monday > 0:
-            monday = monday - timedelta(days=days_since_monday)
-        week_key = f"week_{monday.strftime('%Y-%m-%d')}"
-        
-        # Month: YYYY-MM
-        month_key = f"month_{dt.strftime('%Y-%m')}"
-        
-        # Year: YYYY
-        year_key = f"year_{dt.strftime('%Y')}"
-        
-        return {
-            'week': week_key,
-            'month': month_key,
-            'year': year_key
-        }
+        leaderboard_agg.recompute_for_activity(
+            _exec_sql, athlete_id, start_date_local,
+            user_timezone=user_timezone,
+            activity_timezone=activity_timezone,
+        )
     except Exception as e:
-        print(f"ERROR: Failed to parse activity date {start_date_local}: {e}")
-        return None
-
-
-def update_leaderboard_after_trail_matching(activity_id, athlete_id, distance_on_trail, old_distance_on_trail):
-    """
-    Update leaderboard aggregates after trail matching completes.
-    
-    Args:
-        activity_id: The activity ID
-        athlete_id: The athlete ID
-        distance_on_trail: New distance_on_trail value (after matching)
-        old_distance_on_trail: Old distance_on_trail value (before matching, usually 0)
-    """
-    try:
-        # Check if user has opted in to leaderboards
-        check_sql = "SELECT show_on_leaderboards FROM users WHERE athlete_id = :aid"
-        check_params = [{"name": "aid", "value": {"longValue": athlete_id}}]
-        check_result = _exec_sql(check_sql, check_params)
-        
-        if not check_result.get("records") or not check_result["records"][0][0].get("booleanValue", False):
-            print(f"User {athlete_id} has opted out of leaderboards, skipping aggregation")
-            return
-        
-        # Get activity details for window calculation
-        sql = "SELECT start_date_local, type FROM activities WHERE id = :id"
-        params = [{"name": "id", "value": {"longValue": activity_id}}]
-        result = _exec_sql(sql, params)
-        
-        if not result.get("records"):
-            print(f"Activity {activity_id} not found")
-            return
-        
-        record = result["records"][0]
-        start_date_local = record[0].get("stringValue", "")
-        activity_type = record[1].get("stringValue", "")
-        
-        if not start_date_local:
-            print(f"Activity {activity_id} has no start_date_local")
-            return
-        
-        # Calculate delta (new - old distance_on_trail)
-        distance_delta = distance_on_trail - old_distance_on_trail
-        
-        if distance_delta == 0:
-            print(f"No change in distance_on_trail for activity {activity_id}, skipping leaderboard update")
-            return
-        
-        # Calculate window keys
-        window_keys = get_window_keys(start_date_local)
-        if not window_keys:
-            print(f"Failed to calculate window keys for activity {activity_id}")
-            return
-        
-        # Determine aggregate activity types to update
-        agg_types = ["all"]  # Always update 'all'
-        if activity_type in ["Run", "Walk"]:
-            agg_types.append("foot")
-        elif activity_type == "Ride":
-            agg_types.append("bike")
-        
-        # Update aggregates for each window (week, month, year) and each activity type
-        metric = "distance"
-        for window, window_key in window_keys.items():
-            for agg_activity_type in agg_types:
-                sql = """
-                INSERT INTO leaderboard_agg ("window", window_key, metric, activity_type, athlete_id, value, last_updated)
-                VALUES (:window, :window_key, :metric, :act_type, :aid, :value, now())
-                ON CONFLICT (window_key, metric, activity_type, athlete_id)
-                DO UPDATE SET
-                    value = leaderboard_agg.value + EXCLUDED.value,
-                    last_updated = now()
-                """
-                
-                params = [
-                    {"name": "window", "value": {"stringValue": window}},
-                    {"name": "window_key", "value": {"stringValue": window_key}},
-                    {"name": "metric", "value": {"stringValue": metric}},
-                    {"name": "act_type", "value": {"stringValue": agg_activity_type}},
-                    {"name": "aid", "value": {"longValue": athlete_id}},
-                    {"name": "value", "value": {"doubleValue": distance_delta}},
-                ]
-                
-                _exec_sql(sql, params)
-                print(f"Updated leaderboard aggregate after trail matching: {window_key} athlete={athlete_id} type={agg_activity_type} delta={distance_delta:.2f}m")
-        
-        print(f"Leaderboard updated for activity {activity_id}")
-        
-    except Exception as e:
-        print(f"ERROR: Failed to update leaderboard for activity {activity_id}: {e}")
+        # Don't fail the trail matching if leaderboard update fails — the next
+        # match (or the admin recalc) will heal the row.
+        print(f"ERROR: Failed to recompute leaderboard for athlete {athlete_id}: {e}")
         import traceback
         traceback.print_exc()
-        # Don't fail the trail matching if leaderboard update fails
 
 
 def match_activity(activity_id):
     """Match a single activity against trail data"""
     print(f"Matching activity {activity_id} against trail")
-    
+
     # Initialize variables early to avoid NameError in exception handlers
     athlete_id = None
-    old_distance_on_trail = 0.0
-    
+    start_date_local = ""
+    user_timezone = None
+    activity_timezone = None
+
     try:
         # Get activity from database
         activity = get_activity_from_db(activity_id)
-        
+
         if not activity:
             raise ValueError(f"Activity {activity_id} not found in database")
-        
+
         athlete_id = activity.get("athlete_id")
         if not athlete_id:
             raise ValueError(f"Activity {activity_id} has no athlete_id")
-        
-        old_distance_on_trail = activity.get("old_distance_on_trail", 0.0)
-        
+
+        start_date_local = activity.get("start_date_local", "")
+        user_timezone = activity.get("user_timezone")
+        activity_timezone = activity.get("activity_timezone")
+
         polyline = activity.get("polyline", "")
         if not polyline:
             print(f"Activity {activity_id} has no polyline data, skipping")
             # Still update last_matched to indicate we checked
             update_activity_trail_metrics(activity_id, 0.0, 0)
-            # Update leaderboard if distance_on_trail changed
-            update_leaderboard_after_trail_matching(activity_id, athlete_id, 0.0, old_distance_on_trail)
+            # Recompute leaderboard from activities table (set-based, race-safe)
+            if start_date_local:
+                update_leaderboard_after_trail_matching(
+                    athlete_id, start_date_local, user_timezone, activity_timezone
+                )
             return {
                 "activity_id": activity_id,
                 "distance_on_trail": 0.0,
                 "time_on_trail": 0,
                 "message": "No polyline data"
             }
-        
+
         # Decode activity polyline
         print(f"Decoding polyline for activity {activity_id}")
         activity_coords = decode_polyline(polyline)
         print(f"Decoded {len(activity_coords)} coordinates")
-        
+
         # Try to match against trail data
         # If any error occurs (trail data unavailable, calculation fails, etc.),
         # still update the database with 0 values to indicate we attempted matching
         try:
             # Load trail data from S3
             trail_segments = load_trail_data_from_s3()
-            
+
             # Calculate intersection
             distance_on_trail, time_ratio = calculate_trail_intersection(
                 activity_coords, trail_segments, TRAIL_TOLERANCE_METERS
             )
-            
+
             # Calculate time on trail based on moving_time
             moving_time = activity.get("moving_time", 0)
             time_on_trail = int(moving_time * time_ratio)
-            
+
             # Update database
             update_activity_trail_metrics(activity_id, distance_on_trail, time_on_trail)
-            
-            # Update leaderboard aggregates
-            update_leaderboard_after_trail_matching(activity_id, athlete_id, distance_on_trail, old_distance_on_trail)
-            
+
+            # Recompute leaderboard from activities table (set-based, race-safe)
+            if start_date_local:
+                update_leaderboard_after_trail_matching(
+                    athlete_id, start_date_local, user_timezone, activity_timezone
+                )
+
             print(f"Activity {activity_id} matched: {distance_on_trail:.2f}m, {time_on_trail}s on trail")
-            
+
             return {
                 "activity_id": activity_id,
                 "distance_on_trail": distance_on_trail,
@@ -627,9 +536,10 @@ def match_activity(activity_id):
             print(f"Failed to match activity {activity_id} against trail: {e}")
             print("Setting distance_on_trail=0, time_on_trail=0, and updating last_matched")
             update_activity_trail_metrics(activity_id, 0.0, 0)
-            # Update leaderboard if athlete_id is available
-            if athlete_id:
-                update_leaderboard_after_trail_matching(activity_id, athlete_id, 0.0, old_distance_on_trail)
+            if athlete_id and start_date_local:
+                update_leaderboard_after_trail_matching(
+                    athlete_id, start_date_local, user_timezone, activity_timezone
+                )
             return {
                 "activity_id": activity_id,
                 "distance_on_trail": 0.0,

--- a/backend/webhook_processor/lambda_function.py
+++ b/backend/webhook_processor/lambda_function.py
@@ -15,13 +15,19 @@
 # - Implements idempotency to avoid duplicate processing
 
 import os
+import sys
 import json
 import time
-from datetime import datetime, timezone, timedelta
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 from urllib.parse import urlencode
 import boto3
+
+# Add parent directory to path to import shared modules
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+
+import leaderboard_agg
 
 rds = boto3.client("rds-data")
 sm = boto3.client("secretsmanager")
@@ -305,219 +311,66 @@ def trigger_trail_matching(activity_id):
         return False
 
 
-def get_window_keys(activity_start_date_local):
+def get_activity_window_metadata(athlete_id, strava_activity_id):
+    """Fetch the metadata needed to recompute leaderboard windows for an activity.
+
+    Returns a dict {start_date_local, activity_timezone, user_timezone} or None
+    if the activity isn't in the DB yet. Must be called BEFORE delete_activity
+    on the delete path so we still know which windows to recompute.
     """
-    Calculate window keys for current week, month, and year based on activity date.
-    
-    Args:
-        activity_start_date_local: ISO 8601 timestamp string (e.g., "2026-02-15T10:30:00Z")
-    
-    Returns:
-        Dict with 'week', 'month', 'year' keys containing window_key strings
+    sql = """
+    SELECT a.start_date_local, a.timezone AS activity_timezone, u.timezone AS user_timezone
+      FROM activities a
+      LEFT JOIN users u ON u.athlete_id = a.athlete_id
+     WHERE a.athlete_id = :aid AND a.strava_activity_id = :sid
     """
+    params = [
+        {"name": "aid", "value": {"longValue": athlete_id}},
+        {"name": "sid", "value": {"longValue": strava_activity_id}},
+    ]
     try:
-        # Parse ISO 8601 timestamp
-        dt = datetime.fromisoformat(activity_start_date_local.replace('Z', '+00:00'))
-        
-        # Week: ISO week format, Monday is start of week
-        # Window key format: week_YYYY-MM-DD (Monday of the week)
-        # Get Monday of the current week
-        days_since_monday = dt.weekday()  # Monday is 0
-        monday = dt.replace(hour=0, minute=0, second=0, microsecond=0)
-        if days_since_monday > 0:
-            monday = monday - timedelta(days=days_since_monday)
-        week_key = f"week_{monday.strftime('%Y-%m-%d')}"
-        
-        # Month: YYYY-MM
-        month_key = f"month_{dt.strftime('%Y-%m')}"
-        
-        # Year: YYYY
-        year_key = f"year_{dt.strftime('%Y')}"
-        
-        return {
-            'week': week_key,
-            'month': month_key,
-            'year': year_key
-        }
+        result = _exec_sql(sql, params)
     except Exception as e:
-        print(f"ERROR: Failed to parse activity date {activity_start_date_local}: {e}")
+        print(f"ERROR: Failed to read activity metadata for {strava_activity_id}: {e}")
         return None
 
-
-def check_user_leaderboard_opt_in(athlete_id):
-    """Check if user has opted in to leaderboards (show_on_leaderboards = true)"""
-    sql = "SELECT show_on_leaderboards FROM users WHERE athlete_id = :aid"
-    params = [{"name": "aid", "value": {"longValue": athlete_id}}]
-    
-    try:
-        result = _exec_sql(sql, params)
-        records = result.get("records", [])
-        if not records:
-            print(f"User {athlete_id} not found in database")
-            return False
-        
-        # Get boolean value - handle both booleanValue and stringValue
-        field = records[0][0]
-        if "booleanValue" in field:
-            return field["booleanValue"]
-        elif "stringValue" in field:
-            return field["stringValue"].lower() in ('true', 't', '1')
-        
-        # Default to False if field is NULL or unexpected type
-        return False
-    except Exception as e:
-        print(f"ERROR: Failed to check leaderboard opt-in for user {athlete_id}: {e}")
-        # Default to False on error - safer to not include than to include incorrectly
-        return False
+    records = result.get("records", [])
+    if not records:
+        return None
+    record = records[0]
+    return {
+        "start_date_local": record[0].get("stringValue", "") if not record[0].get("isNull") else "",
+        "activity_timezone": record[1].get("stringValue") if not record[1].get("isNull") else None,
+        "user_timezone": record[2].get("stringValue") if not record[2].get("isNull") else None,
+    }
 
 
-def update_leaderboard_aggregates(athlete_id, activity):
+def recompute_leaderboard_for_activity_window(athlete_id, metadata):
+    """Recompute leaderboard_agg for the user's windows that contain this activity.
+
+    Set-based: derives the user's totals from the current `activities` rows. Run
+    this after a create/update/delete to keep the leaderboard consistent without
+    incremental delta math.
     """
-    Update leaderboard aggregates for an activity (create or update).
-    Increments aggregate values for current week, month, and year.
-    
-    Args:
-        athlete_id: The athlete ID
-        activity: The activity dict from Strava API
-    
-    Returns:
-        True if successful, False otherwise
-    """
-    start_time = time.time()
-    print(f"TELEMETRY - leaderboard_agg_update_start athlete_id={athlete_id} activity_id={activity.get('id')}")
-    
-    try:
-        # Check if user has opted in to leaderboards
-        if not check_user_leaderboard_opt_in(athlete_id):
-            print(f"User {athlete_id} has opted out of leaderboards, skipping aggregation")
-            return True  # Not an error, just skip
-        
-        # Extract activity data from Strava
-        strava_activity_id = activity.get("id")
-        start_date_local = activity.get("start_date_local", "")
-        activity_type = activity.get("type", "")
-        
-        if not start_date_local:
-            print(f"WARNING: Activity {strava_activity_id} has no start_date_local, skipping aggregation")
-            return True
-        
-        # NOTE: Leaderboard uses distance_on_trail, which is calculated by trail matching,
-        # not by Strava webhooks. Strava webhooks update the activity data but preserve
-        # distance_on_trail. Therefore, webhook updates don't change leaderboard rankings.
-        # Trail matching will trigger leaderboard updates when distance_on_trail is calculated.
-        
-        # For now, we skip leaderboard updates in webhook processor since:
-        # - New activities have distance_on_trail = NULL (no change to leaderboard)
-        # - Updated activities preserve distance_on_trail (no change to leaderboard)
-        # - Only trail matching changes distance_on_trail (handled separately)
-        
-        print(f"Skipping leaderboard update for activity {strava_activity_id} - will be updated after trail matching")
+    if not metadata or not metadata.get("start_date_local"):
         return True
-        
-    except Exception as e:
-        duration_ms = (time.time() - start_time) * 1000
-        print(f"TELEMETRY - leaderboard_agg_error athlete_id={athlete_id} error={str(e)} duration_ms={duration_ms:.2f}")
-        print(f"ERROR: Failed to update leaderboard aggregates for athlete {athlete_id}: {e}")
-        import traceback
-        traceback.print_exc()
-        # Don't fail the entire webhook processing if leaderboard update fails
-        return False
 
-
-def delete_leaderboard_aggregates(athlete_id, strava_activity_id):
-    """
-    Remove activity contribution from leaderboard aggregates when activity is deleted.
-    
-    Args:
-        athlete_id: The athlete ID
-        strava_activity_id: The Strava activity ID being deleted
-    
-    Returns:
-        True if successful, False otherwise
-    """
     start_time = time.time()
-    print(f"TELEMETRY - leaderboard_agg_delete_start athlete_id={athlete_id} activity_id={strava_activity_id}")
-    
+    print(f"TELEMETRY - leaderboard_agg_recompute_start athlete_id={athlete_id}")
     try:
-        # Check if user has opted in to leaderboards
-        if not check_user_leaderboard_opt_in(athlete_id):
-            print(f"User {athlete_id} has opted out of leaderboards, no aggregates to delete")
-            return True
-        
-        # Get the activity details before deletion to know what to subtract
-        sql = "SELECT COALESCE(distance_on_trail, 0) as distance, start_date_local, type FROM activities WHERE athlete_id = :aid AND strava_activity_id = :sid"
-        params = [
-            {"name": "aid", "value": {"longValue": athlete_id}},
-            {"name": "sid", "value": {"longValue": strava_activity_id}},
-        ]
-        result = _exec_sql(sql, params)
-        
-        records = result.get("records", [])
-        if not records:
-            print(f"Activity {strava_activity_id} not found, no aggregates to delete")
-            return True
-        
-        # Extract distance, date, and type
-        record = records[0]
-        distance_field = record[0]
-        distance = 0
-        if "doubleValue" in distance_field:
-            distance = float(distance_field["doubleValue"])
-        elif "stringValue" in distance_field:
-            distance = float(distance_field["stringValue"])
-        
-        start_date_local_field = record[1]
-        start_date_local = start_date_local_field.get("stringValue", "")
-        
-        activity_type_field = record[2]
-        activity_type = activity_type_field.get("stringValue", "")
-        
-        if not start_date_local:
-            print(f"Activity {strava_activity_id} has no start_date_local, skipping aggregate deletion")
-            return True
-        
-        # Calculate window keys
-        window_keys = get_window_keys(start_date_local)
-        if not window_keys:
-            print(f"Failed to calculate window keys for activity {strava_activity_id}")
-            return True
-        
-        # Determine which aggregate types to update
-        metric = "distance"
-        agg_types = ["all"]  # Always update 'all'
-        if activity_type in ["Run", "Walk"]:
-            agg_types.append("foot")
-        elif activity_type == "Ride":
-            agg_types.append("bike")
-        
-        # Subtract distance from each window aggregate for each activity type
-        for window, window_key in window_keys.items():
-            for agg_activity_type in agg_types:
-                sql = """
-                UPDATE leaderboard_agg
-                SET value = value - :value, last_updated = now()
-                WHERE window_key = :window_key AND metric = :metric AND activity_type = :act_type AND athlete_id = :aid
-                """
-                
-                params = [
-                    {"name": "value", "value": {"doubleValue": distance}},
-                    {"name": "window_key", "value": {"stringValue": window_key}},
-                    {"name": "metric", "value": {"stringValue": metric}},
-                    {"name": "act_type", "value": {"stringValue": agg_activity_type}},
-                    {"name": "aid", "value": {"longValue": athlete_id}},
-                ]
-                
-                _exec_sql(sql, params)
-                print(f"Deleted from leaderboard aggregate: {window_key} athlete={athlete_id} type={agg_activity_type} distance={distance:.2f}m")
-        
+        leaderboard_agg.recompute_for_activity(
+            _exec_sql,
+            athlete_id,
+            metadata["start_date_local"],
+            user_timezone=metadata.get("user_timezone"),
+            activity_timezone=metadata.get("activity_timezone"),
+        )
         duration_ms = (time.time() - start_time) * 1000
-        print(f"TELEMETRY - leaderboard_agg_delete_complete athlete_id={athlete_id} activity_id={strava_activity_id} duration_ms={duration_ms:.2f}")
+        print(f"TELEMETRY - leaderboard_agg_recompute_complete athlete_id={athlete_id} duration_ms={duration_ms:.2f}")
         return True
-        
     except Exception as e:
         duration_ms = (time.time() - start_time) * 1000
-        print(f"TELEMETRY - leaderboard_agg_delete_error athlete_id={athlete_id} error={str(e)} duration_ms={duration_ms:.2f}")
-        print(f"ERROR: Failed to delete leaderboard aggregates for activity {strava_activity_id}: {e}")
+        print(f"TELEMETRY - leaderboard_agg_recompute_error athlete_id={athlete_id} error={e} duration_ms={duration_ms:.2f}")
         import traceback
         traceback.print_exc()
         return False
@@ -630,10 +483,13 @@ def process_webhook_event(webhook_event):
     activity_id = None
 
     if aspect_type == "delete":
-        # Delete from leaderboard aggregates first (before deleting activity record)
-        delete_leaderboard_aggregates(owner_id, object_id)
-        # Delete activity from database
+        # Capture the activity's window metadata BEFORE the row is gone, then
+        # delete, then recompute the user's leaderboard windows from the
+        # remaining activities (set-based, race-safe).
+        metadata = get_activity_window_metadata(owner_id, object_id)
         success = delete_activity(owner_id, object_id)
+        if success and metadata:
+            recompute_leaderboard_for_activity_window(owner_id, metadata)
     elif aspect_type in ["create", "update"]:
         # Fetch activity details from Strava and store
         try:
@@ -641,11 +497,9 @@ def process_webhook_event(webhook_event):
             activity_id = store_activity(owner_id, activity)
             success = activity_id is not None
 
-            # Update leaderboard aggregates for the activity
-            if success:
-                update_leaderboard_aggregates(owner_id, activity)
-
-            # Trigger trail matching for the activity
+            # No leaderboard update here. distance_on_trail is set by trail
+            # matching, which calls leaderboard_agg.recompute_for_activity
+            # when it completes.
             if success and activity_id:
                 trigger_trail_matching(activity_id)
         except StravaRateLimitError:


### PR DESCRIPTION
## Summary
- Replace the incremental-delta leaderboard update path with a set-based recompute that derives each user's window totals from `SUM(distance_on_trail)` over `activities`
- Eliminates the race that double-counted Morgan's 9.47-mile run (22.92 mi displayed vs. 13.46 mi actual)
- Bonus: also fixes a timezone-drift discrepancy between `match_activity_trail` (naive UTC) and `admin_recalculate_leaderboard` (timezone-aware), and makes partial-failure recovery automatic on the next match

## Why
When Strava sends two webhooks for the same fresh activity quickly (create + immediate update is common), two `match_activity_trail` lambdas race. Both read `old_distance_on_trail = 0`, both add the full distance to `leaderboard_agg`, doubling the contribution. The set-based recompute is idempotent under concurrent calls — both racing lambdas converge to the same final `SUM`.

## Changes
- **NEW** `backend/leaderboard_agg.py` shared module: `recompute_for_activity`, timezone-aware `get_window_bounds`, `get_aggregate_types`, `is_opted_in`
- `backend/match_activity_trail/lambda_function.py`: drop incremental delta path; `get_activity_from_db` now also returns `start_date_local`/`activity_timezone`/`user_timezone` so the recompute call doesn't need a second SELECT
- `backend/webhook_processor/lambda_function.py`: replace `delete_leaderboard_aggregates` with metadata-then-recompute; drop the no-op `update_leaderboard_aggregates` and its caller; drop duplicated `get_window_keys`/`check_user_leaderboard_opt_in`
- `.github/workflows/deploy-lambdas.yml`: bundle the new shared module into both affected lambdas via a new `needs_leaderboard_agg` flag
- New `backend/test_leaderboard_agg.py` (gitignored — `git add -f` if you want it tracked) covers timezone boundary, idempotency, opt-in/out, and SQL emission shape (7/7 pass)

## Test plan
- [ ] CI deploys both lambdas with the bundled `leaderboard_agg.py`
- [ ] Click **Recalculate Leaderboard** in admin once post-deploy → Morgan's week total should drop from 22.92 mi to ~13.46 mi
- [ ] Pick a user with a recent webhook flurry and confirm leaderboard total matches `SELECT SUM(distance_on_trail) FROM activities WHERE athlete_id=… AND start_date_local >= <monday>` for the current week
- [ ] Use admin Reset-Matching on a single activity, watch CloudWatch for `match_activity_trail`, confirm leaderboard value stays consistent on retry
- [ ] Run recalc again 24h later; value should not change

🤖 Generated with [Claude Code](https://claude.com/claude-code)