### PR TITLE
Fix stale rate limit state handling in webhook processor

### DIFF
--- a/backend/scheduled_activity_update/lambda_function.py
+++ b/backend/scheduled_activity_update/lambda_function.py
@@ -47,8 +47,12 @@ TOKEN_REFRESH_BUFFER_SECONDS = 300
 UPDATE_WINDOW_SECONDS = 24 * 60 * 60
 
 # Strava rate limit state (module-level, shared across calls within a single invocation)
+# Strava has two separate rate limits:
+#   - Read endpoints (GET): 300 requests per 15 minutes, 3,000 daily
+#   - Overall (all requests): 600 requests per 15 minutes, 6,000 daily
+# This Lambda uses GET /athlete/activities which counts against the READ limit.
 _rate_limit_used = 0
-_rate_limit_limit = 300  # Strava default read limit
+_rate_limit_limit = 300  # Strava read limit per 15-minute window
 
 # Pause when this many requests remain in the current 15-minute window
 RATE_LIMIT_SAFETY_MARGIN = 5

--- a/backend/webhook_processor/lambda_function.py
+++ b/backend/webhook_processor/lambda_function.py
@@ -41,8 +41,12 @@ MIN_RATE_LIMIT_DEFER_SECONDS = 60
 # SQS caps per-message visibility-timeout extensions at 12 hours.
 MAX_VISIBILITY_TIMEOUT_SECONDS = 12 * 60 * 60
 # Strava rate limit state (read endpoints) observed via response headers.
+# Strava has two separate rate limits:
+#   - Read endpoints (GET): 300 requests per 15 minutes, 3,000 daily
+#   - Overall (all requests): 600 requests per 15 minutes, 6,000 daily
+# This Lambda uses GET /activities/{id} which counts against the READ limit.
 _rate_limit_used = 0
-_rate_limit_limit = 300  # Strava default read limit per 15-minute window.
+_rate_limit_limit = 300  # Strava read limit per 15-minute window
 _rate_limit_last_updated_epoch = 0
 RATE_LIMIT_SAFETY_MARGIN = 5
 RATE_LIMIT_WINDOW_SECONDS = 15 * 60
@@ -260,9 +264,14 @@ def _seconds_until_rate_limit_reset():
 
 def _maybe_start_rate_limit_cooldown():
     """Start cooldown if we're at/near the Strava read rate limit."""
+    global _rate_limit_used
+
     if not _rate_limit_last_updated_epoch:
         return None
     if time.time() - _rate_limit_last_updated_epoch > RATE_LIMIT_STATE_TTL_SECONDS:
+        # Rate limit state is stale (>30 min old). Reset to avoid using
+        # outdated values from a previous Lambda warm-start cycle.
+        _rate_limit_used = 0
         return None
     if _rate_limit_limit <= RATE_LIMIT_SAFETY_MARGIN:
         return None


### PR DESCRIPTION
## Description
Fixes #311 

Reset `_rate_limit_used` when rate limit state is detected as stale (>30 minutes old) to prevent incorrect cooldown decisions in warm Lambda containers.

## Problem
The `_maybe_start_rate_limit_cooldown()` function detected stale rate limit state but didn't reset the global `_rate_limit_used` variable. In warm Lambda containers, this meant:

1. Lambda processes messages and hits `_rate_limit_used = 295`
2. Lambda sits idle for 31+ minutes (stale)
3. Lambda wakes up for new messages
4. Function detects stale state but still has `_rate_limit_used = 295` in memory
5. Could trigger immediate unnecessary cooldown even though Strava's 15-minute window has reset

## Changes
1. Added `global _rate_limit_used` declaration to `_maybe_start_rate_limit_cooldown()`
2. Reset `_rate_limit_used = 0` when stale state is detected
3. Added comment explaining why the reset is necessary
4. Improved documentation to clarify Strava's two separate rate limits:
   - **Read endpoints (GET)**: 300 requests per 15 minutes, 3,000 daily
   - **Overall (all requests)**: 600 requests per 15 minutes, 6,000 daily

## Files Changed
- `backend/webhook_processor/lambda_function.py`
- `backend/scheduled_activity_update/lambda_function.py`

## Testing
- Manual code review of rate limit logic
- Verified Lambda warm-start scenarios
- No tests exist for this function currently (could be a follow-up)

## Impact
- **Risk**: Low - Only affects edge case of stale state in warm containers
- **Benefit**: Prevents incorrect rate limit cooldowns
- **Breaking**: No breaking changes