### PR TITLE
Add Retry-After header to 429 rate limit responses

### DIFF
--- a/backend/fetch_activities/lambda_function.py
+++ b/backend/fetch_activities/lambda_function.py
@@ -546,9 +546,16 @@ def handler(event, context):
             }
         except StravaRateLimitError as e:
             print(f"Strava rate limit hit during direct invocation: {e}")
+            # Return 429 with Retry-After header (RFC 7231)
+            # Using 15-minute Strava rate limit window as retry hint
+            retry_after_seconds = 15 * 60  # 15 minutes
             return {
                 "statusCode": 429,
-                "body": json.dumps({"error": STRAVA_RATE_LIMIT_MESSAGE})
+                "headers": {"Retry-After": str(retry_after_seconds)},
+                "body": json.dumps({
+                    "error": STRAVA_RATE_LIMIT_MESSAGE,
+                    "retry_after": retry_after_seconds
+                })
             }
         except Exception as e:
             print(f"Error in direct invocation: {e}")
@@ -653,11 +660,14 @@ def handler(event, context):
             if remaining > 0:
                 minutes_remaining = (remaining + 59) // 60  # Round up to the next full minute
                 print(f"Fetch cooldown active for athlete {athlete_id}: {remaining}s remaining")
+                # Add Retry-After header (RFC 7231) with exact seconds remaining
+                cors_headers["Retry-After"] = str(remaining)
                 return {
                     "statusCode": 429,
                     "headers": cors_headers,
                     "body": json.dumps({
-                        "error": f"Activities were recently synced. Please wait {minutes_remaining} more minute{'s' if minutes_remaining != 1 else ''} before syncing again."
+                        "error": f"Activities were recently synced. Please wait {minutes_remaining} more minute{'s' if minutes_remaining != 1 else ''} before syncing again.",
+                        "retry_after": remaining
                     })
                 }
         
@@ -683,10 +693,17 @@ def handler(event, context):
         }
     except StravaRateLimitError as e:
         print(f"Strava rate limit exceeded: {e}")
+        # Return 429 with Retry-After header (RFC 7231)
+        # Using 15-minute Strava rate limit window as retry hint
+        retry_after_seconds = 15 * 60  # 15 minutes
+        cors_headers["Retry-After"] = str(retry_after_seconds)
         return {
             "statusCode": 429,
             "headers": cors_headers,
-            "body": json.dumps({"error": STRAVA_RATE_LIMIT_MESSAGE})
+            "body": json.dumps({
+                "error": STRAVA_RATE_LIMIT_MESSAGE,
+                "retry_after": retry_after_seconds
+            })
         }
     except Exception as e:
         print(f"Error in fetch_activities handler: {e}")

--- a/backend/fetch_activities/lambda_function.py
+++ b/backend/fetch_activities/lambda_function.py
@@ -81,6 +81,8 @@ def get_cors_headers():
     if origin:
         headers["Access-Control-Allow-Origin"] = origin
         headers["Access-Control-Allow-Credentials"] = "true"
+        # Expose Retry-After header so JavaScript can read it in CORS requests
+        headers["Access-Control-Expose-Headers"] = "Retry-After"
     return headers
 
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -138,7 +138,12 @@ export const refreshActivities = async () => {
     }
     if (error.response?.status === 429) {
       const message = error.response?.data?.error || 'Strava API rate limit exceeded. Please try again later.';
-      return { success: false, error: message };
+      const retryAfter = error.response?.headers?.['retry-after'] || error.response?.data?.retry_after;
+      return {
+        success: false,
+        error: message,
+        retryAfter: retryAfter ? parseInt(retryAfter) : null
+      };
     }
     return { success: false, error: error.message };
   }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -139,10 +139,27 @@ export const refreshActivities = async () => {
     if (error.response?.status === 429) {
       const message = error.response?.data?.error || 'Strava API rate limit exceeded. Please try again later.';
       const retryAfter = error.response?.headers?.['retry-after'] || error.response?.data?.retry_after;
+
+      // Parse Retry-After: can be either delay-seconds (number) or HTTP-date (RFC 7231)
+      let retryAfterSeconds = null;
+      if (retryAfter) {
+        const num = Number(retryAfter);
+        if (Number.isFinite(num) && num >= 0) {
+          // Numeric delay-seconds format
+          retryAfterSeconds = Math.floor(num);
+        } else {
+          // HTTP-date format: parse and calculate seconds from now
+          const retryDate = new Date(retryAfter);
+          if (!isNaN(retryDate.getTime())) {
+            retryAfterSeconds = Math.max(0, Math.floor((retryDate.getTime() - Date.now()) / 1000));
+          }
+        }
+      }
+
       return {
         success: false,
         error: message,
-        retryAfter: retryAfter ? parseInt(retryAfter) : null
+        retryAfter: retryAfterSeconds
       };
     }
     return { success: false, error: error.message };


### PR DESCRIPTION
## Description
Fixes #317

Adds RFC 7231 compliant `Retry-After` header to all 429 rate limit responses, improving standards compliance and enabling better client-side retry handling.

## Changes

### Backend (`backend/fetch_activities/lambda_function.py`)
Three places now return `Retry-After` header with 429 responses:

1. **Strava rate limit errors (StravaRateLimitError)**: 
   - Returns `Retry-After: 900` (15 minutes)
   - Matches Strava's 15-minute rate limit window

2. **Fetch cooldown errors** (line 660):
   - Returns `Retry-After: <exact seconds remaining>`
   - User-specific cooldown based on last fetch time

3. **Direct invocation rate limit** (line 547):
   - Returns `Retry-After: 900` (15 minutes)

All responses also include `retry_after` in JSON body for easier parsing:
```json
{
  "error": "Rate limit message",
  "retry_after": 900
}
```

### Frontend (`src/utils/api.js`)
Updated `refreshActivities()` to:
- Extract `Retry-After` from response headers or body
- Return `retryAfter` value (in seconds) in error response
- Parse to integer for consistent handling

## Example Responses

### Strava Rate Limit
```http
HTTP/1.1 429 Too Many Requests
Retry-After: 900
Content-Type: application/json

{
  "error": "Strava API rate limit exceeded. Please try again later.",
  "retry_after": 900
}
```

### Fetch Cooldown
```http
HTTP/1.1 429 Too Many Requests
Retry-After: 547
Content-Type: application/json

{
  "error": "Activities were recently synced. Please wait 10 more minutes before syncing again.",
  "retry_after": 547
}
```

## Benefits
- ✅ Standards-compliant HTTP responses (RFC 7231)
- ✅ Clients can programmatically schedule retries
- ✅ Better UX with clear retry timing
- ✅ Both machine-readable (header) and human-friendly (JSON message)

## Testing
- [x] Manual code review of all 429 response paths
- [x] Frontend properly extracts retry timing
- [ ] Integration testing with actual rate limit scenarios (manual testing recommended)

## Breaking Changes
None - adds new fields but doesn't change existing behavior