### PR TITLE
Fix broken leaderboard avatars and add profile picture refresh

### DIFF
--- a/.github/workflows/deploy-lambdas.yml
+++ b/.github/workflows/deploy-lambdas.yml
@@ -91,6 +91,9 @@ jobs:
             secret: LAMBDA_ADMIN_RECALCULATE_LEADERBOARD
             needs_utils: true
             needs_timezone_utils: true
+          - name: admin_refresh_pictures
+            secret: LAMBDA_ADMIN_REFRESH_PICTURES
+            needs_utils: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/DEPLOYMENT_REFRESH_PICTURES.md
+++ b/DEPLOYMENT_REFRESH_PICTURES.md
@@ -1,0 +1,56 @@
+# Deployment: Admin "Refresh Profile Pictures"
+
+Adds an admin button that re-fetches every connected user's Strava profile
+picture, plus a throttled auto-refresh in the hourly scheduled poll. Fixes
+avatars that break when an athlete changes their Strava photo (Strava versions
+its avatar URLs, so a stored URL 404s after the photo changes).
+
+## What changed
+
+**Frontend**
+- `src/components/Avatar.jsx` — new; falls back to the 👤 placeholder when an
+  image fails to load (`onError`). Used in the leaderboard.
+- `src/pages/Leaderboard.jsx` — uses `<Avatar>` for both the top-3 and the table.
+- `src/pages/Admin.jsx` — "Refresh Profile Pictures" button (Global Admin Actions).
+- `src/utils/api.js` — `refreshProfilePictures()` → `POST /admin/refresh-pictures`.
+
+**Backend**
+- `backend/migrations/015_add_profile_picture_updated_at.sql` — tracks last refresh.
+- `backend/scheduled_activity_update/lambda_function.py` — refreshes each user's
+  picture at most once per 7 days while it's already processing that user.
+- `backend/admin_refresh_pictures/lambda_function.py` — new admin endpoint.
+
+## Deploy steps
+
+1. **Run the migration** `015_add_profile_picture_updated_at.sql` against the DB.
+
+2. **Create the Lambda** `rabbitmiles-admin-refresh-pictures`
+   (handler `lambda_function.handler`, Python runtime matching the other admin
+   Lambdas). Deploy code via the `deploy-lambdas.yml` workflow — it's already
+   registered there with `needs_utils: true`, and needs the
+   `LAMBDA_ADMIN_REFRESH_PICTURES` GitHub secret set to the function name.
+
+3. **Set env vars** on the new Lambda (same as other admin Lambdas):
+   `DB_CLUSTER_ARN`, `DB_SECRET_ARN`, `DB_NAME`, `APP_SECRET`, `FRONTEND_URL`,
+   `ADMIN_ATHLETE_IDS`, and Strava creds (`STRAVA_CLIENT_ID`/`STRAVA_CLIENT_SECRET`
+   or `STRAVA_SECRET_ARN`).
+
+4. **IAM**: the execution role needs `rds-data:ExecuteStatement`,
+   `secretsmanager:GetSecretValue`, and **`lambda:InvokeFunction` on itself**
+   (it self-invokes asynchronously to run past API Gateway's 30s timeout).
+   Not in a VPC (RDS Data API requirement).
+
+5. **Configure timeout/memory**: `scripts/configure-admin-refresh-pictures-lambda.sh`
+   (600s timeout so it can wait out a Strava rate-limit window if hit).
+
+6. **Add the API route**: `scripts/setup-admin-refresh-pictures-route.sh`
+   (creates `POST` + `OPTIONS /admin/refresh-pictures`).
+
+7. **Deploy the frontend** build.
+
+## Notes
+- The endpoint returns `202` immediately and does the work in the background;
+  progress is in CloudWatch logs for the Lambda.
+- Rate-limit aware: makes one Strava read per user. If it approaches the read
+  limit (300/15 min) it waits or stops cleanly — remaining users keep their
+  current picture and get caught up by the next run or another click.

--- a/backend/admin_refresh_pictures/lambda_function.py
+++ b/backend/admin_refresh_pictures/lambda_function.py
@@ -1,0 +1,380 @@
+# admin_refresh_pictures Lambda function
+# Admin endpoint to re-fetch every connected user's Strava profile picture.
+#
+# Strava versions its avatar URLs, so a URL captured at login 404s once the
+# athlete changes their photo. This endpoint force-refreshes all stored
+# pictures on demand (the hourly scheduled poll also does this, but throttled).
+#
+# Path: POST /admin/refresh-pictures
+#
+# Because refreshing every user makes one Strava GET per user (which can exceed
+# API Gateway's 30s timeout), the request handler validates admin auth and then
+# self-invokes asynchronously to do the work in the background, mirroring
+# admin_recalculate_leaderboard.
+#
+# Env vars required:
+# DB_CLUSTER_ARN, DB_SECRET_ARN, DB_NAME=postgres
+# STRAVA_CLIENT_ID, STRAVA_CLIENT_SECRET (or STRAVA_SECRET_ARN)
+# APP_SECRET (for session verification)
+# FRONTEND_URL (for CORS)
+# ADMIN_ATHLETE_IDS (comma-separated list of admin athlete IDs)
+
+import os
+import json
+import time
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+from urllib.parse import urlencode, urlparse
+import boto3
+
+import admin_utils
+
+rds = boto3.client("rds-data")
+sm = boto3.client("secretsmanager")
+lambda_client = boto3.client("lambda")
+
+# Get environment variables
+DB_CLUSTER_ARN = os.environ.get("DB_CLUSTER_ARN", "")
+DB_SECRET_ARN = os.environ.get("DB_SECRET_ARN", "")
+DB_NAME = os.environ.get("DB_NAME", "postgres")
+APP_SECRET_STR = os.environ.get("APP_SECRET", "")
+APP_SECRET = APP_SECRET_STR.encode() if APP_SECRET_STR else b""
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "").rstrip("/")
+LAMBDA_FUNCTION_NAME = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "")
+
+STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token"
+STRAVA_ATHLETE_URL = "https://www.strava.com/api/v3/athlete"
+
+# Token refresh buffer - refresh tokens 5 minutes before expiry
+TOKEN_REFRESH_BUFFER_SECONDS = 300
+
+# Strava read rate limit (300 requests / 15 min). Pause when this many remain.
+RATE_LIMIT_LIMIT = 300
+RATE_LIMIT_SAFETY_MARGIN = 5
+MAX_RETRIES = 3
+MAX_RETRY_WAIT_SECONDS = 120
+# Leave headroom before the async Lambda's own timeout when deciding to sleep.
+LAMBDA_TIME_REMAINING_SAFETY_MS = 30 * 1000
+
+# Module-level rate-limit tracking within a single invocation.
+_rate_limit_used = 0
+
+
+def get_cors_origin():
+    """Extract origin (scheme + host) from FRONTEND_URL for CORS headers"""
+    if not FRONTEND_URL:
+        return None
+    parsed = urlparse(FRONTEND_URL)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _get_strava_creds():
+    """Get Strava client credentials from env or Secrets Manager"""
+    client_id = os.environ.get("STRAVA_CLIENT_ID")
+    client_secret = os.environ.get("STRAVA_CLIENT_SECRET")
+    secret_arn = os.environ.get("STRAVA_SECRET_ARN")
+
+    if (not client_id or not client_secret) and secret_arn:
+        resp = sm.get_secret_value(SecretId=secret_arn)
+        data = json.loads(resp["SecretString"])
+        client_id = client_id or str(data.get("client_id") or data.get("clientId"))
+        client_secret = client_secret or str(data.get("client_secret") or data.get("clientSecret"))
+
+    if not client_id or not client_secret:
+        raise RuntimeError("Missing STRAVA_CLIENT_ID/STRAVA_CLIENT_SECRET")
+
+    return client_id, client_secret
+
+
+def exec_sql(sql, parameters=None):
+    """Execute SQL using RDS Data API"""
+    kwargs = dict(
+        resourceArn=DB_CLUSTER_ARN,
+        secretArn=DB_SECRET_ARN,
+        sql=sql,
+        database=DB_NAME,
+    )
+    if parameters:
+        kwargs["parameters"] = parameters
+    return rds.execute_statement(**kwargs)
+
+
+def refresh_access_token(athlete_id, refresh_token):
+    """Refresh expired Strava access token and persist it."""
+    client_id, client_secret = _get_strava_creds()
+
+    body = urlencode({
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }).encode()
+
+    req = Request(STRAVA_TOKEN_URL, data=body, headers={"Content-Type": "application/x-www-form-urlencoded"})
+    with urlopen(req, timeout=20) as resp:
+        token_resp = json.loads(resp.read().decode())
+
+    access_token = token_resp.get("access_token")
+    new_refresh_token = token_resp.get("refresh_token")
+    expires_at = int(token_resp.get("expires_at") or 0)
+    if not access_token:
+        raise RuntimeError(f"Token refresh failed: {token_resp}")
+
+    sql = """
+    UPDATE users
+    SET access_token = :at, refresh_token = :rt, expires_at = :exp, updated_at = now()
+    WHERE athlete_id = :aid
+    """
+    exec_sql(sql, [
+        {"name": "at", "value": {"stringValue": access_token}},
+        {"name": "rt", "value": {"stringValue": new_refresh_token}},
+        {"name": "exp", "value": {"longValue": expires_at}},
+        {"name": "aid", "value": {"longValue": athlete_id}},
+    ])
+    print(f"LOG - Refreshed access token for athlete {athlete_id}")
+    return access_token
+
+
+def ensure_valid_token(athlete_id, access_token, refresh_token, expires_at):
+    """Ensure access token is valid, refresh if needed"""
+    if expires_at < int(time.time()) + TOKEN_REFRESH_BUFFER_SECONDS:
+        return refresh_access_token(athlete_id, refresh_token)
+    return access_token
+
+
+def _update_rate_limit_from_headers(headers):
+    """Track Strava read-limit usage from response headers."""
+    global _rate_limit_used
+    usage = (
+        headers.get("X-ReadRateLimit-Usage")
+        or headers.get("x-readratelimit-usage")
+        or headers.get("X-RateLimit-Usage")
+        or headers.get("x-ratelimit-usage")
+    )
+    if usage:
+        try:
+            _rate_limit_used = int(usage.split(",")[0])
+        except (ValueError, IndexError):
+            pass
+
+
+def _remaining_lambda_ms(context):
+    if context and hasattr(context, "get_remaining_time_in_millis"):
+        try:
+            return context.get_remaining_time_in_millis()
+        except Exception:
+            return float("inf")
+    return float("inf")
+
+
+class RateLimitExhaustedError(Exception):
+    """Raised when waiting out the rate-limit window would exceed our Lambda budget."""
+
+
+def _wait_if_rate_limited(context):
+    """Pause if approaching Strava's 15-minute read limit."""
+    global _rate_limit_used
+    if _rate_limit_used >= RATE_LIMIT_LIMIT - RATE_LIMIT_SAFETY_MARGIN:
+        seconds_into_window = time.time() % (15 * 60)
+        wait = (15 * 60) - seconds_into_window + 5
+        if wait * 1000 > _remaining_lambda_ms(context) - LAMBDA_TIME_REMAINING_SAFETY_MS:
+            raise RateLimitExhaustedError("not enough Lambda time to wait out rate limit window")
+        print(f"LOG - Rate limit approaching ({_rate_limit_used}/{RATE_LIMIT_LIMIT}), sleeping {wait:.0f}s")
+        time.sleep(wait)
+        _rate_limit_used = 0
+
+
+def fetch_strava_athlete(access_token, context):
+    """Fetch athlete profile from Strava (rate-limit aware, retries on 429)."""
+    req = Request(STRAVA_ATHLETE_URL, headers={"Authorization": f"Bearer {access_token}"})
+    for attempt in range(MAX_RETRIES + 1):
+        _wait_if_rate_limited(context)
+        try:
+            with urlopen(req, timeout=20) as resp:
+                body = resp.read().decode()
+                _update_rate_limit_from_headers(dict(resp.headers))
+                return json.loads(body)
+        except HTTPError as e:
+            if e.code == 429 and attempt < MAX_RETRIES:
+                wait = min(60 * (2 ** attempt), MAX_RETRY_WAIT_SECONDS)
+                if wait * 1000 > _remaining_lambda_ms(context) - LAMBDA_TIME_REMAINING_SAFETY_MS:
+                    raise RateLimitExhaustedError("not enough Lambda time to retry after 429") from e
+                print(f"LOG - 429 received, retrying in {wait}s (attempt {attempt + 1}/{MAX_RETRIES})")
+                time.sleep(wait)
+                continue
+            print(f"LOG - Failed to fetch athlete profile: HTTP {e.code}")
+            return None
+        except Exception as e:
+            print(f"LOG - Failed to fetch athlete profile: {e}")
+            return None
+
+
+def get_connected_users():
+    """Get all users connected to Strava (have tokens)."""
+    sql = """
+    SELECT athlete_id, access_token, refresh_token, expires_at
+    FROM users
+    WHERE access_token IS NOT NULL AND refresh_token IS NOT NULL
+    ORDER BY athlete_id
+    """
+    result = exec_sql(sql)
+    users = []
+    for record in result.get("records", []):
+        athlete_id = int(record[0].get("longValue", 0))
+        access_token = record[1].get("stringValue", "")
+        refresh_token = record[2].get("stringValue", "")
+        expires_at = int(record[3].get("longValue", 0))
+        if athlete_id and access_token and refresh_token:
+            users.append({
+                "athlete_id": athlete_id,
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "expires_at": expires_at,
+            })
+    return users
+
+
+def persist_profile_picture(athlete_id, athlete):
+    """Persist the athlete's current profile picture to the database."""
+    if not isinstance(athlete, dict):
+        return False
+    profile_picture = athlete.get("profile_medium") or athlete.get("profile") or ""
+
+    sql = """
+    UPDATE users
+    SET profile_picture = :pic,
+        profile_picture_updated_at = now(),
+        updated_at = now()
+    WHERE athlete_id = :aid
+    """
+    params = [{"name": "aid", "value": {"longValue": athlete_id}}]
+    if profile_picture:
+        params.append({"name": "pic", "value": {"stringValue": profile_picture}})
+    else:
+        params.append({"name": "pic", "value": {"isNull": True}})
+
+    exec_sql(sql, params)
+    return True
+
+
+def refresh_all_pictures(context):
+    """Re-fetch and persist every connected user's profile picture."""
+    users = get_connected_users()
+    print(f"LOG - Refreshing pictures for {len(users)} connected users")
+
+    updated = 0
+    failed = 0
+    aborted = False
+    for user in users:
+        athlete_id = user["athlete_id"]
+        try:
+            access_token = ensure_valid_token(
+                athlete_id, user["access_token"], user["refresh_token"], user["expires_at"]
+            )
+            athlete = fetch_strava_athlete(access_token, context)
+            if athlete and persist_profile_picture(athlete_id, athlete):
+                updated += 1
+            else:
+                failed += 1
+        except RateLimitExhaustedError:
+            # Stop cleanly; remaining users keep their existing pictures and the
+            # hourly poll (or a repeat click) will catch them up.
+            print("LOG - Rate limit budget exhausted; stopping early")
+            aborted = True
+            break
+        except Exception as e:
+            print(f"LOG - Failed to refresh picture for athlete {athlete_id}: {e}")
+            failed += 1
+
+    return {
+        "total_users": len(users),
+        "updated": updated,
+        "failed": failed,
+        "aborted": aborted,
+    }
+
+
+def handler(event, context):
+    print("=" * 80)
+    print("ADMIN REFRESH PICTURES - START")
+    print("=" * 80)
+
+    start_time = time.time()
+    cors_origin = get_cors_origin()
+    headers = admin_utils.get_admin_headers(cors_origin)
+
+    # Background invocation: skip auth (already verified) and do the work.
+    if event.get("async_invocation") is True:
+        print("LOG - Running as async invocation (background task)")
+        if not DB_CLUSTER_ARN or not DB_SECRET_ARN:
+            print("ERROR - Missing DB_CLUSTER_ARN or DB_SECRET_ARN")
+            return {"statusCode": 500, "body": json.dumps({"error": "server configuration error"})}
+
+        result = refresh_all_pictures(context)
+        duration_ms = (time.time() - start_time) * 1000
+        print(f"LOG - Refreshed {result['updated']}/{result['total_users']} pictures "
+              f"({result['failed']} failed) in {duration_ms:.0f}ms")
+        print("=" * 80)
+        print("ADMIN REFRESH PICTURES - SUCCESS")
+        print("=" * 80)
+        return {"statusCode": 200, "body": json.dumps({**result, "duration_ms": round(duration_ms, 2)})}
+
+    # Handle OPTIONS preflight requests
+    if event.get("requestContext", {}).get("http", {}).get("method") == "OPTIONS":
+        return {
+            "statusCode": 200,
+            "headers": {
+                **headers,
+                "Access-Control-Allow-Methods": "POST, OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type, Cookie",
+                "Access-Control-Max-Age": "86400",
+            },
+            "body": "",
+        }
+
+    try:
+        if not DB_CLUSTER_ARN or not DB_SECRET_ARN or not APP_SECRET or not LAMBDA_FUNCTION_NAME:
+            print("ERROR - Missing required environment variables")
+            return {"statusCode": 500, "headers": headers, "body": json.dumps({"error": "server configuration error"})}
+
+        athlete_id, is_admin = admin_utils.verify_admin_session(event, APP_SECRET)
+        if not athlete_id:
+            return {"statusCode": 401, "headers": headers, "body": json.dumps({"error": "not authenticated"})}
+        if not is_admin:
+            admin_utils.audit_log_admin_action(
+                athlete_id, "/admin/refresh-pictures", "access_denied", {"reason": "not in admin allowlist"}
+            )
+            return {"statusCode": 403, "headers": headers, "body": json.dumps({"error": "forbidden"})}
+
+        print(f"LOG - Admin {athlete_id} triggering profile picture refresh")
+        admin_utils.audit_log_admin_action(
+            athlete_id, "/admin/refresh-pictures", "refresh_pictures_triggered"
+        )
+
+        # Self-invoke asynchronously to run past the API Gateway 30s timeout.
+        response = lambda_client.invoke(
+            FunctionName=LAMBDA_FUNCTION_NAME,
+            InvocationType="Event",
+            Payload=json.dumps({"async_invocation": True, "triggered_by_athlete_id": athlete_id}),
+        )
+        status_code = response.get("StatusCode")
+        if status_code not in [200, 202]:
+            print(f"ERROR - Lambda invocation returned unexpected status code: {status_code}")
+            return {"statusCode": 500, "headers": headers, "body": json.dumps({"error": "Failed to trigger refresh"})}
+
+        return {
+            "statusCode": 202,
+            "headers": headers,
+            "body": json.dumps({
+                "message": "Profile picture refresh started. This runs in the background and may take a minute.",
+                "status": "processing",
+            }),
+        }
+
+    except Exception as e:
+        print(f"ERROR - Unexpected exception: {type(e).__name__}: {e}")
+        import traceback
+        traceback.print_exc()
+        return {"statusCode": 500, "headers": headers, "body": json.dumps({"error": "internal server error"})}

--- a/backend/migrations/015_add_profile_picture_updated_at.sql
+++ b/backend/migrations/015_add_profile_picture_updated_at.sql
@@ -1,0 +1,11 @@
+-- Add profile_picture_updated_at column to users table
+-- This records when a user's profile_picture was last refreshed from Strava.
+-- Strava versions its avatar URLs, so a URL captured at login goes stale (404s)
+-- once the athlete changes their photo. The hourly scheduled poll uses this
+-- column to refresh each athlete's picture at most once per PROFILE_PIC_REFRESH
+-- window, keeping the extra Strava read requests negligible.
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS profile_picture_updated_at TIMESTAMP;
+
+COMMENT ON COLUMN users.profile_picture_updated_at IS 'Timestamp of the last successful profile_picture refresh from Strava. Used by the scheduled poll to throttle per-user avatar refreshes.';

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -37,3 +37,5 @@ psql -h DATABASE_HOST -U USERNAME -d postgres -f backend/migrations/001_create_o
 - `008_create_leaderboard_agg_table.sql` - Creates the `leaderboard_agg` table for aggregated leaderboard data
 - `009_add_user_timezone.sql` - Adds `timezone` column to `users` table for per-user timezone preference
 - `010_add_last_strava_fetch.sql` - Adds `last_strava_fetch` column to `users` table to track the last successful Strava fetch per athlete and enforce a per-user cooldown
+- `011_add_last_webhook_received.sql` - Adds `last_webhook_received_at` column to `users` table to track when webhooks last delivered activity updates
+- `015_add_profile_picture_updated_at.sql` - Adds `profile_picture_updated_at` column to `users` table to throttle per-user profile-picture refreshes (migrations 012-014 belong to the email-notifications feature and land separately)

--- a/backend/scheduled_activity_update/lambda_function.py
+++ b/backend/scheduled_activity_update/lambda_function.py
@@ -35,6 +35,14 @@ DB_NAME = None
 
 STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token"
 STRAVA_ACTIVITIES_URL = "https://www.strava.com/api/v3/athlete/activities"
+STRAVA_ATHLETE_URL = "https://www.strava.com/api/v3/athlete"
+
+# Refresh each athlete's profile picture at most this often. Strava versions its
+# avatar URLs, so a stored URL 404s once the athlete changes their photo. We
+# re-fetch the athlete profile (one extra GET, counted against the read limit)
+# only when the picture hasn't been refreshed within this window, keeping the
+# added rate-limit cost negligible.
+PROFILE_PIC_REFRESH_SECONDS = 7 * 24 * 60 * 60  # 7 days
 
 # Filter activities starting from Jan 1, 2026 00:00:00 UTC
 # Unix timestamp: 1767225600
@@ -288,6 +296,51 @@ def fetch_strava_activities(access_token, after_timestamp, context=None, per_pag
         raise
 
 
+def fetch_strava_athlete(access_token, context=None):
+    """Fetch the athlete profile from Strava (rate-limit aware)."""
+    req = Request(STRAVA_ATHLETE_URL, headers={"Authorization": f"Bearer {access_token}"})
+    try:
+        return _strava_get(req, context=context, timeout=20)
+    except Exception as e:
+        log(f"Failed to fetch athlete profile from Strava: {e}", "WARNING")
+        return None
+
+
+def refresh_profile_picture(athlete_id, access_token, context=None):
+    """Re-fetch the athlete's profile picture from Strava and persist it.
+
+    Only called when the picture is stale (see PROFILE_PIC_REFRESH_SECONDS).
+    Always stamps profile_picture_updated_at on a successful fetch so we don't
+    retry every hour, even when the athlete has no custom photo.
+    """
+    athlete = fetch_strava_athlete(access_token, context=context)
+    if not isinstance(athlete, dict):
+        return False
+
+    profile_picture = athlete.get("profile_medium") or athlete.get("profile") or ""
+
+    sql = """
+    UPDATE users
+    SET profile_picture = :pic,
+        profile_picture_updated_at = now(),
+        updated_at = now()
+    WHERE athlete_id = :aid
+    """
+    params = [{"name": "aid", "value": {"longValue": athlete_id}}]
+    if profile_picture:
+        params.append({"name": "pic", "value": {"stringValue": profile_picture}})
+    else:
+        params.append({"name": "pic", "value": {"isNull": True}})
+
+    try:
+        _exec_sql(sql, params)
+        log(f"Refreshed profile picture for athlete {athlete_id}", "INFO")
+        return True
+    except Exception as e:
+        log(f"Failed to persist profile picture for athlete {athlete_id}: {e}", "WARNING")
+        return False
+
+
 def store_activity(athlete_id, activity):
     """Store or update activity in database"""
     strava_activity_id = activity.get("id")
@@ -378,7 +431,11 @@ def get_users_needing_poll():
     (so this works before migration 011 has run).
     """
     sql_with_filter = f"""
-    SELECT athlete_id, access_token, refresh_token, expires_at
+    SELECT athlete_id, access_token, refresh_token, expires_at,
+      (
+        profile_picture_updated_at IS NULL
+        OR profile_picture_updated_at < NOW() - INTERVAL '{PROFILE_PIC_REFRESH_SECONDS} seconds'
+      ) AS profile_pic_stale
     FROM users
     WHERE access_token IS NOT NULL
       AND refresh_token IS NOT NULL
@@ -388,8 +445,11 @@ def get_users_needing_poll():
       )
     ORDER BY athlete_id
     """
+    # Fallback for before migrations 011/015 have run. Marks pictures as
+    # not-stale so we never attempt a refresh against a missing column.
     sql_fallback = """
-    SELECT athlete_id, access_token, refresh_token, expires_at
+    SELECT athlete_id, access_token, refresh_token, expires_at,
+      false AS profile_pic_stale
     FROM users
     WHERE access_token IS NOT NULL
       AND refresh_token IS NOT NULL
@@ -398,7 +458,7 @@ def get_users_needing_poll():
     try:
         result = _exec_sql(sql_with_filter)
     except Exception as e:
-        log(f"last_webhook_received_at filter failed ({e}); falling back to all connected users", "WARNING")
+        log(f"user poll filter failed ({e}); falling back to all connected users", "WARNING")
         result = _exec_sql(sql_fallback)
 
     users = []
@@ -407,13 +467,15 @@ def get_users_needing_poll():
         access_token = record[1].get("stringValue", "")
         refresh_token = record[2].get("stringValue", "")
         expires_at = int(record[3].get("longValue", 0))
+        profile_pic_stale = bool(record[4].get("booleanValue", False))
 
         if athlete_id and access_token and refresh_token:
             users.append({
                 "athlete_id": athlete_id,
                 "access_token": access_token,
                 "refresh_token": refresh_token,
-                "expires_at": expires_at
+                "expires_at": expires_at,
+                "profile_pic_stale": profile_pic_stale
             })
 
     return users
@@ -459,6 +521,13 @@ def update_recent_activities_for_user(user, context=None):
                 failed_count += 1
 
         log(f"User {athlete_id}: Stored {stored_count}, Failed {failed_count} out of {len(activities)} activities", "INFO")
+
+        # Refresh the profile picture if it hasn't been updated recently. Strava
+        # versions its avatar URLs, so this repairs pictures that went stale
+        # after an athlete changed their photo. Throttled to at most once per
+        # PROFILE_PIC_REFRESH_SECONDS so the extra read request stays cheap.
+        if user.get("profile_pic_stale"):
+            refresh_profile_picture(athlete_id, access_token, context=context)
 
         return {
             "athlete_id": athlete_id,

--- a/scripts/configure-admin-refresh-pictures-lambda.sh
+++ b/scripts/configure-admin-refresh-pictures-lambda.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Configuration script for admin_refresh_pictures Lambda
+# This script sets the appropriate timeout and memory settings
+
+set -e
+
+LAMBDA_NAME="rabbitmiles-admin-refresh-pictures"
+TIMEOUT=600  # 10 minutes - enough time to fetch one profile per user (and wait out a rate-limit window if hit)
+MEMORY=256   # 256MB - light workload, one Strava GET + one UPDATE per user
+
+echo "========================================"
+echo "Configuring Lambda: $LAMBDA_NAME"
+echo "========================================"
+echo ""
+
+# Check if AWS CLI is available
+if ! command -v aws &> /dev/null; then
+    echo "❌ AWS CLI not found. Please install AWS CLI first."
+    exit 1
+fi
+
+echo "Setting Lambda configuration:"
+echo "  Timeout: ${TIMEOUT}s (10 minutes)"
+echo "  Memory: ${MEMORY}MB"
+echo ""
+
+# Update Lambda configuration
+OUTPUT=$(aws lambda update-function-configuration \
+  --function-name "$LAMBDA_NAME" \
+  --timeout "$TIMEOUT" \
+  --memory-size "$MEMORY" 2>&1)
+
+if [ $? -ne 0 ]; then
+    echo "❌ Failed to update Lambda configuration"
+    echo ""
+    echo "Error details:"
+    echo "$OUTPUT"
+    echo ""
+    echo "Possible causes:"
+    echo "  - Lambda function doesn't exist"
+    echo "  - AWS credentials don't have Lambda update permissions"
+    echo "  - Function is currently being updated (wait 30 seconds and retry)"
+    echo ""
+    exit 1
+fi
+
+echo ""
+echo "✅ Configuration updated successfully"
+echo ""
+
+# Verify the configuration
+echo "📊 Current Lambda Configuration:"
+aws lambda get-function-configuration \
+  --function-name "$LAMBDA_NAME" \
+  --query '[FunctionName,Timeout,MemorySize,LastModified]' \
+  --output table
+
+echo ""
+echo "========================================"
+echo "✅ Configuration Complete"
+echo "========================================"

--- a/scripts/setup-admin-refresh-pictures-route.sh
+++ b/scripts/setup-admin-refresh-pictures-route.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# Setup script for admin_refresh_pictures API Gateway route
+# This script helps create the POST /admin/refresh-pictures route in API Gateway
+
+set -e
+
+echo "🚀 RabbitMiles Admin Refresh Pictures Route Setup"
+echo "========================================================="
+echo ""
+
+# Check for required tools
+if ! command -v aws &> /dev/null; then
+    echo "❌ Error: AWS CLI not found. Please install it first."
+    exit 1
+fi
+
+# Check AWS credentials
+if ! aws sts get-caller-identity &> /dev/null; then
+    echo "❌ Error: AWS credentials not configured."
+    echo "Please run: aws configure"
+    exit 1
+fi
+
+echo "✅ AWS CLI configured"
+echo ""
+
+# Get AWS region
+AWS_REGION=${AWS_REGION:-us-east-1}
+echo "Using AWS region: $AWS_REGION"
+echo ""
+
+# Prompt for API Gateway ID if not provided
+if [ -z "$API_GATEWAY_ID" ]; then
+    echo "📋 Finding your API Gateway HTTP API..."
+    echo ""
+    
+    # List available HTTP APIs
+    APIS=$(aws apigatewayv2 get-apis --query 'Items[?ProtocolType==`HTTP`].[ApiId,Name]' --output text)
+    
+    if [ -z "$APIS" ]; then
+        echo "❌ No HTTP APIs found in region $AWS_REGION"
+        exit 1
+    fi
+    
+    echo "Available HTTP APIs:"
+    echo "$APIS"
+    echo ""
+    
+    read -p "Enter your API Gateway ID: " API_GATEWAY_ID
+fi
+
+echo "Using API Gateway ID: $API_GATEWAY_ID"
+echo ""
+
+# Verify API exists
+if ! aws apigatewayv2 get-api --api-id "$API_GATEWAY_ID" &> /dev/null; then
+    echo "❌ Error: API Gateway with ID $API_GATEWAY_ID not found"
+    exit 1
+fi
+
+API_NAME=$(aws apigatewayv2 get-api --api-id "$API_GATEWAY_ID" --query 'Name' --output text)
+echo "API Name: $API_NAME"
+echo ""
+
+# Prompt for Lambda function name if not provided
+if [ -z "$LAMBDA_FUNCTION_NAME" ]; then
+    echo "📋 Finding admin_refresh_pictures Lambda function..."
+    echo ""
+    
+    # Try common Lambda function names
+    for name in "rabbitmiles-admin-refresh-pictures" "prod-admin-refresh-pictures" "admin-refresh-pictures"; do
+        if aws lambda get-function --function-name "$name" &> /dev/null 2>&1; then
+            LAMBDA_FUNCTION_NAME="$name"
+            echo "✅ Found Lambda function: $LAMBDA_FUNCTION_NAME"
+            break
+        fi
+    done
+    
+    if [ -z "$LAMBDA_FUNCTION_NAME" ]; then
+        echo "⚠️  Could not auto-detect Lambda function name"
+        read -p "Enter your admin_refresh_pictures Lambda function name: " LAMBDA_FUNCTION_NAME
+    fi
+fi
+
+echo "Using Lambda function: $LAMBDA_FUNCTION_NAME"
+echo ""
+
+# Verify Lambda exists
+if ! aws lambda get-function --function-name "$LAMBDA_FUNCTION_NAME" &> /dev/null; then
+    echo "❌ Error: Lambda function $LAMBDA_FUNCTION_NAME not found"
+    exit 1
+fi
+
+# Get Lambda ARN
+LAMBDA_ARN=$(aws lambda get-function --function-name "$LAMBDA_FUNCTION_NAME" --query 'Configuration.FunctionArn' --output text)
+echo "Lambda ARN: $LAMBDA_ARN"
+echo ""
+
+# Get AWS Account ID
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+# Check if route already exists
+echo "🔍 Checking if POST /admin/refresh-pictures route exists..."
+ROUTE_EXISTS=$(aws apigatewayv2 get-routes --api-id "$API_GATEWAY_ID" \
+    --query 'Items[?RouteKey==`POST /admin/refresh-pictures`].RouteId' --output text)
+
+if [ -n "$ROUTE_EXISTS" ]; then
+    echo "⚠️  Route POST /admin/refresh-pictures already exists (Route ID: $ROUTE_EXISTS)"
+    read -p "Do you want to recreate it? (y/N): " RECREATE
+    if [[ "$RECREATE" =~ ^[Yy]$ ]]; then
+        echo "🗑️  Deleting existing route..."
+        aws apigatewayv2 delete-route --api-id "$API_GATEWAY_ID" --route-id "$ROUTE_EXISTS"
+        echo "✅ Deleted existing route"
+    else
+        echo "✅ Keeping existing route"
+        exit 0
+    fi
+fi
+echo ""
+
+# Check if integration exists for this Lambda
+echo "🔍 Checking for existing Lambda integration..."
+INTEGRATION_ID=$(aws apigatewayv2 get-integrations --api-id "$API_GATEWAY_ID" \
+    --query "Items[?IntegrationUri==\`$LAMBDA_ARN\`].IntegrationId" --output text)
+
+if [ -z "$INTEGRATION_ID" ]; then
+    echo "📦 Creating Lambda integration..."
+    INTEGRATION_ID=$(aws apigatewayv2 create-integration \
+        --api-id "$API_GATEWAY_ID" \
+        --integration-type AWS_PROXY \
+        --integration-uri "$LAMBDA_ARN" \
+        --payload-format-version "2.0" \
+        --query 'IntegrationId' \
+        --output text)
+    echo "✅ Created integration: $INTEGRATION_ID"
+else
+    echo "✅ Using existing integration: $INTEGRATION_ID"
+fi
+echo ""
+
+# Create the POST route
+echo "🛣️  Creating POST /admin/refresh-pictures route..."
+ROUTE_ID=$(aws apigatewayv2 create-route \
+    --api-id "$API_GATEWAY_ID" \
+    --route-key "POST /admin/refresh-pictures" \
+    --target "integrations/$INTEGRATION_ID" \
+    --query 'RouteId' \
+    --output text)
+echo "✅ Created route: $ROUTE_ID"
+echo ""
+
+# Create OPTIONS route for CORS preflight
+echo "🛣️  Creating OPTIONS /admin/refresh-pictures route for CORS..."
+OPTIONS_ROUTE_EXISTS=$(aws apigatewayv2 get-routes --api-id "$API_GATEWAY_ID" \
+    --query 'Items[?RouteKey==`OPTIONS /admin/refresh-pictures`].RouteId' --output text)
+
+if [ -z "$OPTIONS_ROUTE_EXISTS" ]; then
+    OPTIONS_ROUTE_ID=$(aws apigatewayv2 create-route \
+        --api-id "$API_GATEWAY_ID" \
+        --route-key "OPTIONS /admin/refresh-pictures" \
+        --target "integrations/$INTEGRATION_ID" \
+        --query 'RouteId' \
+        --output text)
+    echo "✅ Created OPTIONS route: $OPTIONS_ROUTE_ID"
+else
+    echo "✅ OPTIONS route already exists: $OPTIONS_ROUTE_EXISTS"
+fi
+echo ""
+
+# Add Lambda permission for API Gateway to invoke the function
+echo "🔐 Adding Lambda permission for API Gateway..."
+
+# Use a consistent statement ID
+STATEMENT_ID="apigateway-admin-refresh-pictures"
+
+# Remove existing permission if any (ignore errors if it doesn't exist)
+aws lambda remove-permission \
+    --function-name "$LAMBDA_FUNCTION_NAME" \
+    --statement-id "$STATEMENT_ID" \
+    &> /dev/null || true
+
+# Add the permission with consistent statement ID
+aws lambda add-permission \
+    --function-name "$LAMBDA_FUNCTION_NAME" \
+    --statement-id "$STATEMENT_ID" \
+    --action lambda:InvokeFunction \
+    --principal apigateway.amazonaws.com \
+    --source-arn "arn:aws:execute-api:$AWS_REGION:$ACCOUNT_ID:$API_GATEWAY_ID/*/*/admin/refresh-pictures" \
+    &> /dev/null
+
+echo "✅ Lambda permission added"
+echo ""
+
+# Get API endpoint
+API_ENDPOINT=$(aws apigatewayv2 get-api --api-id "$API_GATEWAY_ID" --query 'ApiEndpoint' --output text)
+
+# Output summary
+echo "=================================="
+echo "✅ Setup Complete!"
+echo "=================================="
+echo ""
+echo "📋 Configuration Summary:"
+echo ""
+echo "API Gateway ID: $API_GATEWAY_ID"
+echo "API Endpoint: $API_ENDPOINT"
+echo "Route: POST /admin/refresh-pictures"
+echo "Lambda Function: $LAMBDA_FUNCTION_NAME"
+echo "Integration ID: $INTEGRATION_ID"
+echo "Route ID: $ROUTE_ID"
+echo ""
+echo "🧪 Testing:"
+echo ""
+echo "Test the endpoint with an admin session cookie:"
+echo ""
+echo "curl -X POST $API_ENDPOINT/admin/refresh-pictures \\"
+echo "  -H \"Cookie: rm_session=your-admin-session-cookie\" \\"
+echo "  -H \"Content-Type: application/json\" \\"
+echo "  -v"
+echo ""
+echo "Expected response (202 - refresh runs asynchronously in the background):"
+echo "{\"message\": \"Profile picture refresh started. This runs in the background and may take a minute.\", \"status\": \"processing\"}"
+echo ""
+echo "⚠️  Important Notes:"
+echo ""
+echo "1. Ensure your Lambda has these environment variables set:"
+echo "   - APP_SECRET"
+echo "   - FRONTEND_URL"
+echo "   - DB_CLUSTER_ARN"
+echo "   - DB_SECRET_ARN"
+echo "   - DB_NAME"
+echo "   - ADMIN_ATHLETE_IDS (comma-separated)"
+echo "   - STRAVA_CLIENT_ID + STRAVA_CLIENT_SECRET (or STRAVA_SECRET_ARN)"
+echo ""
+echo "2. Ensure your Lambda has IAM permissions for:"
+echo "   - rds-data:ExecuteStatement"
+echo "   - secretsmanager:GetSecretValue"
+echo "   - lambda:InvokeFunction on itself (it self-invokes to run in the background)"
+echo ""
+echo "3. The Lambda function must NOT be in a VPC (RDS Data API requirement)"
+echo ""
+echo "For detailed instructions, see DEPLOYMENT_REFRESH_PICTURES.md"
+echo ""

--- a/src/components/Avatar.jsx
+++ b/src/components/Avatar.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+// Renders an athlete's profile picture, falling back to a placeholder when the
+// image is missing or fails to load. Strava versions its avatar URLs, so a URL
+// stored before an athlete changed their photo will 404 — onError catches that
+// and swaps in the placeholder instead of showing a broken-image icon.
+function Avatar({ src, alt, className = '' }) {
+  // Track the specific URL that failed rather than a boolean, so that when
+  // `src` changes (e.g. after a background profile-picture refresh) the new URL
+  // is retried instead of staying stuck on the placeholder.
+  const [failedSrc, setFailedSrc] = useState(null);
+
+  const showImage = src && failedSrc !== src;
+
+  if (showImage) {
+    return (
+      <img
+        src={src}
+        alt={alt}
+        className={`rounded-full ${className}`}
+        onError={() => setFailedSrc(src)}
+      />
+    );
+  }
+
+  return (
+    <div className={`rounded-full bg-gray-200 flex items-center justify-center ${className}`}>
+      <span className="text-gray-500">👤</span>
+    </div>
+  );
+}
+
+export default Avatar;

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { fetchMe, fetchAllUsers, fetchAllActivities, fetchUserActivities, deleteUser, backfillUserActivities, updateUserActivities, recalculateLeaderboard } from '../utils/api';
+import { fetchMe, fetchAllUsers, fetchAllActivities, fetchUserActivities, deleteUser, backfillUserActivities, updateUserActivities, recalculateLeaderboard, refreshProfilePictures } from '../utils/api';
 import { useNavigate } from 'react-router-dom';
 import analytics from '../utils/analytics';
 
@@ -20,6 +20,7 @@ function Admin() {
   const [backfillingActivities, setBackfillingActivities] = useState(false);
   const [updatingActivities, setUpdatingActivities] = useState(false);
   const [recalculatingLeaderboard, setRecalculatingLeaderboard] = useState(false);
+  const [refreshingPictures, setRefreshingPictures] = useState(false);
   const [deleteConfirmUser, setDeleteConfirmUser] = useState(null);
   const [deleting, setDeleting] = useState(false);
   const [successMessage, setSuccessMessage] = useState(null);
@@ -266,6 +267,23 @@ function Admin() {
     setRecalculatingLeaderboard(false);
   };
 
+  const handleRefreshPictures = async () => {
+    setRefreshingPictures(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    const result = await refreshProfilePictures();
+    if (result.success) {
+      setSuccessMessage(
+        result.data.message ||
+          'Profile picture refresh started. This runs in the background and may take a minute.'
+      );
+    } else {
+      setError(result.error || 'Failed to refresh profile pictures');
+    }
+    setRefreshingPictures(false);
+  };
+
   const loadMoreActivities = async () => {
     if (loadingMoreActivities || !hasMoreActivities) return;
     
@@ -409,6 +427,30 @@ function Admin() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
               </svg>
               Recalculate Leaderboard
+            </>
+          )}
+        </button>
+
+        <button
+          onClick={handleRefreshPictures}
+          disabled={refreshingPictures}
+          className="inline-flex items-center px-4 py-2 border border-teal-300 shadow-sm text-sm font-medium rounded-md text-teal-700 bg-white hover:bg-teal-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Re-fetch every connected user's profile picture from Strava"
+        >
+          {refreshingPictures ? (
+            <>
+              <svg className="animate-spin -ml-0.5 mr-2 h-4 w-4 text-teal-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              Refreshing Pictures...
+            </>
+          ) : (
+            <>
+              <svg className="-ml-0.5 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              Refresh Profile Pictures
             </>
           )}
         </button>

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchMe, fetchLeaderboard } from '../utils/api';
 import analytics from '../utils/analytics';
+import Avatar from '../components/Avatar';
 
 // Number of top athletes to display in current rankings
 const TOP_ATHLETES_COUNT = 15;
@@ -208,17 +209,11 @@ function Leaderboard() {
                     <div className="text-2xl sm:text-3xl">
                       {idx === 0 ? '🥇' : idx === 1 ? '🥈' : '🥉'}
                     </div>
-                    {entry.user.avatar_url ? (
-                      <img
-                        src={entry.user.avatar_url}
-                        alt={entry.user.display_name}
-                        className="w-8 h-8 sm:w-10 sm:h-10 rounded-full"
-                      />
-                    ) : (
-                      <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-gray-200 flex items-center justify-center">
-                        <span className="text-sm sm:text-base text-gray-500">👤</span>
-                      </div>
-                    )}
+                    <Avatar
+                      src={entry.user.avatar_url}
+                      alt={entry.user.display_name}
+                      className="w-8 h-8 sm:w-10 sm:h-10"
+                    />
                     <div className="text-left">
                       <p className="font-semibold text-gray-900 text-xs sm:text-sm">{entry.user.display_name}</p>
                       <p className="text-sm sm:text-base font-bold text-orange-600">{formatDistance(entry.value)} mi</p>
@@ -296,17 +291,11 @@ function Leaderboard() {
                             rel="noopener noreferrer"
                             className="flex items-center hover:opacity-80 transition-opacity"
                           >
-                            {entry.user.avatar_url ? (
-                              <img
-                                src={entry.user.avatar_url}
-                                alt={entry.user.display_name}
-                                className="w-8 h-8 sm:w-10 sm:h-10 rounded-full mr-2 sm:mr-3"
-                              />
-                            ) : (
-                              <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-gray-200 flex items-center justify-center mr-2 sm:mr-3">
-                                <span className="text-gray-500">👤</span>
-                              </div>
-                            )}
+                            <Avatar
+                              src={entry.user.avatar_url}
+                              alt={entry.user.display_name}
+                              className="w-8 h-8 sm:w-10 sm:h-10 mr-2 sm:mr-3"
+                            />
                             <div>
                               <div className="text-sm font-medium text-gray-900">
                                 {entry.user.display_name}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -402,6 +402,27 @@ export const recalculateLeaderboard = async () => {
   }
 };
 
+// Refresh all users' Strava profile pictures (admin only)
+export const refreshProfilePictures = async () => {
+  try {
+    debug.log('Calling POST /admin/refresh-pictures endpoint...');
+    const response = await api.post('/admin/refresh-pictures');
+    debug.log('POST /admin/refresh-pictures response received:', response.data);
+    return { success: true, data: response.data };
+  } catch (error) {
+    console.error('POST /admin/refresh-pictures endpoint error:', error.message);
+    if (error.response?.status === 401) {
+      debug.log('User not authenticated (401)');
+      return { success: false, notConnected: true };
+    }
+    if (error.response?.status === 403) {
+      debug.log('User not authorized for admin access (403)');
+      return { success: false, error: 'Access denied - admin privileges required' };
+    }
+    return { success: false, error: error.response?.data?.message || error.response?.data?.error || error.message };
+  }
+};
+
 // Fetch period summary with projections
 export const fetchPeriodSummary = async () => {
   try {


### PR DESCRIPTION
## Problem
Some leaderboard avatars showed broken-image icons (e.g. Ben, Joe). Strava versions its profile-picture URLs, so a URL captured at login **404s once the athlete changes their photo**. The hourly poll had stopped refreshing pictures to save rate-limit budget, so stale URLs were never repaired.

## Changes

**Frontend**
- New `Avatar` component with an `onError` fallback to the 👤 placeholder; used in both leaderboard spots so a failed image never renders a broken-image icon.
- Admin **Refresh Profile Pictures** button (Global Admin Actions) + `refreshProfilePictures()` API helper.

**Backend**
- Migration `015_add_profile_picture_updated_at.sql` — tracks last refresh per user.
- `scheduled_activity_update` — refreshes each user's picture at most once per 7 days while already processing them (rate-limit aware); falls back safely if the new column is absent.
- New `admin_refresh_pictures` Lambda — admin-triggered refresh of all connected users' pictures. Returns `202` and self-invokes asynchronously to beat API Gateway's 30s timeout; rate-limit aware.
- Registered `admin_refresh_pictures` in `deploy-lambdas.yml`.

## Deployment
Infrastructure (function, env vars, IAM, API route, GitHub secret, DB migration) is already provisioned. Merging deploys the Lambda code and frontend via the existing workflows. Full checklist in `DEPLOYMENT_REFRESH_PICTURES.md`.

## Verification
Python compiles, frontend lints and builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)