### PR TITLE
Reconcile activity metadata Strava changes after upload

### DIFF
--- a/DEPLOYMENT_ACTIVITY_METADATA_REFRESH.md
+++ b/DEPLOYMENT_ACTIVITY_METADATA_REFRESH.md
@@ -1,0 +1,164 @@
+# Deployment: Activity Metadata Refresh
+
+Covers the fix for stale `athlete_count` (group badges never appearing) and for
+activity renames/re-types that were never reconciled after a missed webhook.
+
+**Deploy order:** run step 1 (the migration) before step 2 (the Lambda deploy) so the
+refresh sweep is live the first time the hourly schedule fires. Getting it backwards
+is safe, not just survivable — `get_users_needing_poll()` detects the missing column,
+logs `has migration 016 run?`, and degrades to exactly the previous
+webhook-freshness-only behaviour (*not* to "poll everyone", which would have
+multiplied Strava read usage). The sweep simply does not start until the column
+exists.
+
+---
+
+## Step 1 — Run migration 016 (do this first)
+
+Adds `users.last_metadata_refresh_at`. Idempotent (`ADD COLUMN IF NOT EXISTS`), so
+re-running is harmless.
+
+```bash
+aws rds-data execute-statement \
+  --resource-arn "$DB_CLUSTER_ARN" \
+  --secret-arn "$DB_SECRET_ARN" \
+  --database postgres \
+  --sql "$(cat backend/migrations/016_add_last_metadata_refresh.sql)"
+```
+
+Verify the column exists:
+
+```bash
+aws rds-data execute-statement \
+  --resource-arn "$DB_CLUSTER_ARN" \
+  --secret-arn "$DB_SECRET_ARN" \
+  --database postgres \
+  --sql "SELECT column_name FROM information_schema.columns
+         WHERE table_name='users' AND column_name='last_metadata_refresh_at'"
+```
+
+Expect one row back. An empty result means the migration did not apply — stop and
+fix that before merging, otherwise step 3's verification will show no sweep activity.
+
+---
+
+## Step 2 — Deploy the Lambdas
+
+Merging this PR to `main` triggers `.github/workflows/deploy-lambdas.yml`
+(it fires on any push touching `backend/**`) and deploys all seven changed functions.
+No new GitHub secrets, IAM changes, env vars, or EventBridge changes are needed —
+the existing `scheduled-activity-update-hourly` rule is reused as-is.
+
+Functions changed by this PR:
+
+| Lambda | Change |
+| --- | --- |
+| `webhook_processor` | Now writes `athlete_count` (was silently omitted) |
+| `scheduled_activity_update` | 7-day window; sweeps all users; stamps `last_metadata_refresh_at` |
+| `user_update_activities` | Paginates all pages instead of page 1 only |
+| `fetch_activities` | Polyline downgrade fix |
+| `update_activities` | Polyline downgrade fix |
+| `admin_update_activities` | Polyline downgrade fix |
+| `admin_backfill_activities` | Polyline downgrade fix |
+
+Confirm all seven matrix jobs went green in the Actions run before moving on.
+
+---
+
+## Step 3 — Verify the sweep is running
+
+Wait for the next hourly EventBridge fire (or invoke manually):
+
+```bash
+aws lambda invoke \
+  --function-name "$LAMBDA_SCHEDULED_ACTIVITY_UPDATE" \
+  --payload '{}' response.json && cat response.json
+```
+
+In CloudWatch Logs for that function, look for:
+
+- `Found N users to poll (webhook-stale or refresh-sweep due)` — on the first run
+  after the migration, `N` should equal your **total** connected user count, since
+  no one has been swept yet. On later runs it settles to whoever is due.
+- `Rate limit usage: X/300` — confirm this stays well under 300.
+- Absence of `page full (...) were NOT refreshed` warnings. If you see one, a user
+  has more than 200 activities inside the 7-day window and the tail was skipped.
+
+Then confirm the stamps are landing:
+
+```bash
+aws rds-data execute-statement \
+  --resource-arn "$DB_CLUSTER_ARN" \
+  --secret-arn "$DB_SECRET_ARN" \
+  --database postgres \
+  --sql "SELECT count(*) AS total,
+                count(last_metadata_refresh_at) AS swept
+         FROM users WHERE access_token IS NOT NULL"
+```
+
+`swept` should climb toward `total` over the first few hours. Users are processed
+25 per invocation with self-continuation, so a large user base takes a few runs.
+
+---
+
+## Step 4 — One-time repair of rows older than 7 days
+
+The sweep only reconciles the last 7 days. Activities older than that keep whatever
+`athlete_count` they were first written with, so they need one backfill pass.
+
+**Use `admin_update_activities` (or the user-facing "Update activities" button), not
+`backfill_athlete_count`.** The admin/user paths read Strava's *list* endpoint — one
+request covers 200 activities. `backfill_athlete_count` reads the *detail* endpoint
+once per activity: 100 requests to fix 100 activities, which burns a third of the
+daily read quota per user and has no rate-limit handling. It remains in the repo for
+targeted single-activity investigation only.
+
+Check what actually needs repair first:
+
+```bash
+aws rds-data execute-statement \
+  --resource-arn "$DB_CLUSTER_ARN" \
+  --secret-arn "$DB_SECRET_ARN" \
+  --database postgres \
+  --sql "SELECT count(*) FROM activities
+         WHERE start_date < now() - interval '7 days'
+           AND (athlete_count IS NULL OR athlete_count = 1)"
+```
+
+That count is an upper bound, not a to-do list — most of those really are solo
+activities. Then trigger the repair per athlete via the admin endpoint, and re-run
+the query to see the count drop.
+
+Because `user_update_activities` now paginates, a user pressing "Update activities"
+repairs their whole season rather than only their most recent 200 activities. If a
+user has more than 2,000 activities in range it stops at the `MAX_PAGES` limit and
+says so in the response `message`, with `truncated: true` — press it again to continue.
+
+---
+
+## Rollback
+
+Revert the merge commit and let `deploy-lambdas.yml` redeploy. **Leave the column in
+place** — it is additive, nothing outside `scheduled_activity_update` reads it, and
+dropping it is pure risk. The reverted code simply stops writing to it.
+
+There is no data to undo: every change either writes a previously-unwritten field or
+makes an existing write more conservative.
+
+---
+
+## What this does not fix
+
+Called out so it does not read as covered:
+
+- **Changing an activity's `type` can change leaderboard eligibility, and no
+  leaderboard recompute is triggered.** The refresh updates `activities.type`, but
+  `leaderboard_agg` is only recomputed by trail matching and the webhook delete path.
+  A Run re-typed as a Ride keeps its leaderboard contribution until something else
+  forces a recompute. Pre-existing, and worth a follow-up.
+- **Strava athlete deauthorization is still ignored.** `webhook/lambda_function.py`
+  drops any event where `object_type != "activity"`, so an `athlete` event carrying
+  `updates: {authorized: "false"}` is discarded and the user stays marked connected
+  until a token refresh fails. Pre-existing, unrelated to this PR.
+- **Activities before Jan 1 2026** are out of range everywhere via
+  `ACTIVITIES_START_DATE`. Unchanged by this PR.

--- a/backend/admin_backfill_activities/lambda_function.py
+++ b/backend/admin_backfill_activities/lambda_function.py
@@ -175,6 +175,10 @@ def store_activities(athlete_id, activities):
             polyline = activity["map"].get("polyline") or activity["map"].get("summary_polyline", "")
         
         # Insert or update activity
+        # polyline is COALESCEd, not overwritten: this reads Strava's list endpoint,
+        # whose SummaryActivity carries only map.summary_polyline. Assigning it
+        # directly would downgrade a full polyline stored by webhook_processor from
+        # the detail endpoint. COALESCE still fills the column when it is empty.
         sql = """
         INSERT INTO activities (
             athlete_id, strava_activity_id, name, distance, moving_time, elapsed_time,
@@ -193,7 +197,7 @@ def store_activities(athlete_id, activities):
             start_date = EXCLUDED.start_date,
             start_date_local = EXCLUDED.start_date_local,
             timezone = EXCLUDED.timezone,
-            polyline = EXCLUDED.polyline,
+            polyline = COALESCE(activities.polyline, EXCLUDED.polyline),
             athlete_count = EXCLUDED.athlete_count,
             time_on_trail = COALESCE(activities.time_on_trail, EXCLUDED.time_on_trail),
             distance_on_trail = COALESCE(activities.distance_on_trail, EXCLUDED.distance_on_trail),

--- a/backend/admin_update_activities/lambda_function.py
+++ b/backend/admin_update_activities/lambda_function.py
@@ -275,6 +275,10 @@ def store_activity(athlete_id, activity):
     # Note: time_on_trail and distance_on_trail are computed separately by trail matching logic
     # We initialize them as NULL and preserve existing values on update using COALESCE
     # This ensures computed trail metrics aren't accidentally overwritten during activity updates
+    # polyline is COALESCEd, not overwritten: this reads Strava's list endpoint,
+    # whose SummaryActivity carries only map.summary_polyline. Assigning it
+    # directly would downgrade a full polyline stored by webhook_processor from
+    # the detail endpoint. COALESCE still fills the column when it is empty.
     sql = """
     INSERT INTO activities (
         athlete_id, strava_activity_id, name, distance, moving_time, elapsed_time,
@@ -293,7 +297,7 @@ def store_activity(athlete_id, activity):
         start_date = EXCLUDED.start_date,
         start_date_local = EXCLUDED.start_date_local,
         timezone = EXCLUDED.timezone,
-        polyline = EXCLUDED.polyline,
+        polyline = COALESCE(activities.polyline, EXCLUDED.polyline),
         athlete_count = EXCLUDED.athlete_count,
         time_on_trail = COALESCE(activities.time_on_trail, EXCLUDED.time_on_trail),
         distance_on_trail = COALESCE(activities.distance_on_trail, EXCLUDED.distance_on_trail),

--- a/backend/fetch_activities/lambda_function.py
+++ b/backend/fetch_activities/lambda_function.py
@@ -327,6 +327,10 @@ def store_activities(athlete_id, activities):
         # Note: time_on_trail, distance_on_trail, and last_matched are initialized as NULL
         # time_on_trail and distance_on_trail will be computed later through trail intersection calculations
         # last_matched will be set when the activity is checked against trail matching database
+        # polyline is COALESCEd, not overwritten: this reads Strava's list endpoint,
+        # whose SummaryActivity carries only map.summary_polyline. Assigning it
+        # directly would downgrade a full polyline stored by webhook_processor from
+        # the detail endpoint. COALESCE still fills the column when it is empty.
         sql = """
         INSERT INTO activities (
             athlete_id, strava_activity_id, name, distance, moving_time, elapsed_time,
@@ -345,7 +349,7 @@ def store_activities(athlete_id, activities):
             start_date = EXCLUDED.start_date,
             start_date_local = EXCLUDED.start_date_local,
             timezone = EXCLUDED.timezone,
-            polyline = EXCLUDED.polyline,
+            polyline = COALESCE(activities.polyline, EXCLUDED.polyline),
             athlete_count = EXCLUDED.athlete_count,
             time_on_trail = COALESCE(activities.time_on_trail, EXCLUDED.time_on_trail),
             distance_on_trail = COALESCE(activities.distance_on_trail, EXCLUDED.distance_on_trail),

--- a/backend/migrations/016_add_last_metadata_refresh.sql
+++ b/backend/migrations/016_add_last_metadata_refresh.sql
@@ -1,0 +1,20 @@
+-- Add last_metadata_refresh_at column to users table
+-- Strava mutates activity fields after upload: athlete_count grows as the other
+-- participants upload their copy of a group activity, and athletes rename or
+-- re-type activities long after the fact. Webhooks cover most of this, but a
+-- missed webhook leaves the row permanently stale because the hourly poll only
+-- looks back 24 hours and skips webhook-fresh users entirely.
+--
+-- This column lets scheduled_activity_update run a slower, unconditional
+-- refresh sweep over *every* connected user (not just webhook-stale ones)
+-- without re-polling the same user every hour. One list request per user per
+-- sweep covers a multi-day window, so the added rate-limit cost is 4 read
+-- requests per user per day at a 6-hour cadence.
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS last_metadata_refresh_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_users_last_metadata_refresh_at
+    ON users(last_metadata_refresh_at);
+
+COMMENT ON COLUMN users.last_metadata_refresh_at IS 'Timestamp of the last successful activity-metadata refresh sweep for this user. Used by scheduled_activity_update to poll every connected user on a slow cadence, independent of webhook freshness.';

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -39,3 +39,4 @@ psql -h DATABASE_HOST -U USERNAME -d postgres -f backend/migrations/001_create_o
 - `010_add_last_strava_fetch.sql` - Adds `last_strava_fetch` column to `users` table to track the last successful Strava fetch per athlete and enforce a per-user cooldown
 - `011_add_last_webhook_received.sql` - Adds `last_webhook_received_at` column to `users` table to track when webhooks last delivered activity updates
 - `015_add_profile_picture_updated_at.sql` - Adds `profile_picture_updated_at` column to `users` table to throttle per-user profile-picture refreshes (migrations 012-014 belong to the email-notifications feature and land separately)
+- `016_add_last_metadata_refresh.sql` - Adds `last_metadata_refresh_at` column to `users` table so the scheduled poll can sweep every connected user for renames and `athlete_count` changes on a slow cadence, independent of webhook freshness

--- a/backend/scheduled_activity_update/README.md
+++ b/backend/scheduled_activity_update/README.md
@@ -1,20 +1,37 @@
 # Scheduled Activity Update Lambda
 
-This Lambda function runs on a schedule (every hour) to automatically update activities from the last 24 hours for all connected users from the Strava API.
+This Lambda runs every hour and serves two purposes with a single Strava request per user:
+
+1. **Webhook backstop** — picks up activities for users whose webhooks have not delivered in over 6 hours.
+2. **Metadata refresh sweep** — re-reads a 7-day window for *every* connected user at least once every 6 hours.
 
 ## Purpose
 
-Ensures that activity data (including `athlete_count` for group activities) is kept up-to-date automatically without requiring manual user intervention.
+Strava keeps mutating activities after upload, and not all of it generates a webhook we can rely on:
+
+- `athlete_count` grows as the *other* participants upload their copy of a group activity — minutes to days after the fact. This is why a value written once at ingest is wrong so often.
+- Athletes rename activities and change their type long after uploading.
+
+Webhooks cover most of this, but a webhook that is missed (subscription lapse, DLQ, rate-limit deferral) previously left the row stale forever: the hourly poll only looked back 24 hours *and* skipped any user whose webhooks were flowing. That excluded the most active users from all reconciliation. The refresh sweep closes that gap.
 
 ## Functionality
 
-1. Queries database for all users with valid Strava tokens
+1. Selects connected users that are **due** — either webhook-stale (>6h) or sweep-due (`last_metadata_refresh_at` older than 6h, or never). Ordered oldest-sweep-first so a backlog drains fairly instead of always serving the lowest athlete IDs.
 2. For each user:
-   - Refreshes Strava access token if needed
-   - Fetches activities from the last 24 hours from Strava API
-   - Updates or inserts activities in the database
-   - Preserves existing trail matching data (time_on_trail, distance_on_trail)
-3. Returns summary of updates performed
+   - Refreshes the Strava access token if needed
+   - Fetches activities from the last 7 days (one list request)
+   - Updates or inserts activities, refreshing `name`, `type`, `athlete_count`, distance and time fields
+   - Preserves trail matching data (`time_on_trail`, `distance_on_trail`) via COALESCE
+   - Preserves any full `polyline` already stored by `webhook_processor` — the list endpoint only returns `summary_polyline`, so assigning it directly would downgrade the stored route
+   - Refreshes the profile picture if it is older than 7 days
+   - Stamps `last_metadata_refresh_at` on success only, so a failure is retried on the next run instead of waiting out a full sweep interval
+3. Returns a summary of updates performed
+
+## Rate limit budget
+
+Strava allows 300 read requests per 15 minutes and 3,000 per day. The sweep costs **1 read request per user per 6 hours** — 4 per user per day — which stays inside the daily read quota up to roughly 700 connected users. Widening the lookback window from 24 hours to 7 days costs nothing extra: it is the same single list request either way.
+
+If you outgrow that, raise `METADATA_REFRESH_SECONDS` (sweep less often) rather than shrinking the window.
 
 ## Environment Variables Required
 
@@ -142,8 +159,11 @@ Monitor Lambda execution in:
 
 ## Notes
 
-- The Lambda fetches activities after timestamp: `max(ACTIVITIES_START_DATE, current_time - 24h)`
+- The Lambda fetches activities after timestamp: `max(ACTIVITIES_START_DATE, current_time - 7d)`
 - ACTIVITIES_START_DATE is Jan 1, 2026 (timestamp: 1767225600)
 - Updates preserve existing trail matching data using COALESCE
 - Access tokens are automatically refreshed if within 5 minutes of expiry
 - The Lambda processes users sequentially (not in parallel) to avoid rate limits
+- Requires migration `016_add_last_metadata_refresh.sql`. Before it runs, `get_users_needing_poll()` falls back to selecting all connected users and the sweep clause is inert — the Lambda still works, it just behaves as it did before this change
+- A single page (200 activities) is the cap per user per run. If a user somehow exceeds that inside the window, a `WARNING` is logged naming the unrefreshed tail rather than silently truncating
+- Only reconciles the **last 7 days**. Repairing older rows is a one-time job — see `DEPLOYMENT_ACTIVITY_METADATA_REFRESH.md`

--- a/backend/scheduled_activity_update/lambda_function.py
+++ b/backend/scheduled_activity_update/lambda_function.py
@@ -1,7 +1,11 @@
 # scheduled_activity_update Lambda function
-# Runs every hour to update recent activities for all connected users
-# Updates activities from the last 24 hours from Strava API
-# 
+# Runs every hour. Two jobs, both served by a single Strava list request per user:
+#   1. Backstop for missed webhooks (users webhook-stale for >6h).
+#   2. Metadata refresh sweep over every connected user at least every 6h, which
+#      reconciles the fields Strava mutates after upload — athlete_count for
+#      group activities, plus renames and re-types.
+# Each poll looks back 7 days (UPDATE_WINDOW_SECONDS).
+#
 # Env vars required:
 # DB_CLUSTER_ARN, DB_SECRET_ARN, DB_NAME=postgres
 # STRAVA_CLIENT_ID, STRAVA_CLIENT_SECRET (or STRAVA_SECRET_ARN)
@@ -51,8 +55,13 @@ ACTIVITIES_START_DATE = 1767225600
 # Token refresh buffer - refresh tokens 5 minutes before expiry
 TOKEN_REFRESH_BUFFER_SECONDS = 300
 
-# Update activities from the last 24 hours
-UPDATE_WINDOW_SECONDS = 24 * 60 * 60
+# How far back each poll looks. Strava keeps mutating activities after upload:
+# athlete_count grows as the other participants upload their copy of a group
+# activity (minutes to days later), and athletes rename or re-type activities
+# well after the fact. A 24-hour window missed all of that, so the window is
+# sized to the realistic group-matching lag instead. Cost is unchanged — this is
+# still a single paginated list request per user regardless of window length.
+UPDATE_WINDOW_SECONDS = 7 * 24 * 60 * 60
 
 # Strava rate limit state (module-level, shared across calls within a single invocation)
 # Strava has two separate rate limits:
@@ -76,6 +85,18 @@ MAX_RETRY_WAIT_SECONDS = 120
 # Skip users whose data was already kept fresh by webhooks within this window.
 # The hourly job is only a backstop for missed webhooks.
 WEBHOOK_FRESHNESS_SECONDS = 6 * 60 * 60  # 6 hours
+
+# Regardless of webhook freshness, sweep every connected user at least this
+# often. Webhook freshness alone was not enough: a user whose webhooks are
+# flowing was never polled, so a *missed* webhook (subscription lapse, DLQ,
+# rate-limit deferral) left that activity stale forever. This sweep is the
+# catch-all. At a 6-hour cadence it costs 4 read requests per user per day,
+# which stays well inside Strava's 3,000/day read quota up to ~700 users.
+METADATA_REFRESH_SECONDS = 6 * 60 * 60  # 6 hours
+
+# Warn when a single list page comes back full: the window may hold more
+# activities than we fetched, so the tail went unrefreshed. Never silently cap.
+ACTIVITIES_PER_PAGE = 200
 
 # How many users to process per invocation. If more users remain, we self-invoke
 # the lambda to continue, so one Lambda execution never spans more than this many.
@@ -370,6 +391,15 @@ def store_activity(athlete_id, activity):
     # Note: time_on_trail and distance_on_trail are computed separately by trail matching logic
     # We initialize them as NULL and preserve existing values on update using COALESCE
     # This ensures computed trail metrics aren't accidentally overwritten during activity updates
+    #
+    # polyline is also COALESCEd rather than overwritten. This lambda reads the
+    # *list* endpoint, whose SummaryActivity only carries map.summary_polyline —
+    # so assigning EXCLUDED.polyline downgraded any full polyline that
+    # webhook_processor had stored from the detail endpoint. COALESCE still
+    # populates the column when it is empty, but never trades detail for
+    # summary. (Trade-off: if an athlete crops an existing route, the refreshed
+    # summary polyline is ignored here; the update webhook, which does read the
+    # detail endpoint, corrects it.)
     sql = """
     INSERT INTO activities (
         athlete_id, strava_activity_id, name, distance, moving_time, elapsed_time,
@@ -388,7 +418,7 @@ def store_activity(athlete_id, activity):
         start_date = EXCLUDED.start_date,
         start_date_local = EXCLUDED.start_date_local,
         timezone = EXCLUDED.timezone,
-        polyline = EXCLUDED.polyline,
+        polyline = COALESCE(activities.polyline, EXCLUDED.polyline),
         athlete_count = EXCLUDED.athlete_count,
         time_on_trail = COALESCE(activities.time_on_trail, EXCLUDED.time_on_trail),
         distance_on_trail = COALESCE(activities.distance_on_trail, EXCLUDED.distance_on_trail),
@@ -421,16 +451,51 @@ def store_activity(athlete_id, activity):
 
 
 def get_users_needing_poll():
-    """Get connected users that webhooks have not kept fresh recently.
+    """Get connected users due for a poll.
 
-    Skips users whose last_webhook_received_at is within WEBHOOK_FRESHNESS_SECONDS
-    so we only poll the backstop set, not every connected user. Users that have
-    never received a webhook are always included.
+    A user is due when EITHER:
+      - webhooks have not kept them fresh (last_webhook_received_at older than
+        WEBHOOK_FRESHNESS_SECONDS, or never), or
+      - their metadata refresh sweep is due (last_metadata_refresh_at older than
+        METADATA_REFRESH_SECONDS, or never).
 
-    Falls back to "all connected users" if the column does not yet exist
-    (so this works before migration 011 has run).
+    The second clause is what guarantees every connected user is eventually
+    swept. Webhook freshness alone excluded the most active users from all
+    polling, so a single missed webhook — or any of Strava's post-upload
+    mutations (renames, re-types, athlete_count growth) that fire no webhook at
+    all — never got reconciled.
+
+    Ordered oldest-refresh-first so that when there are more users than fit in
+    one invocation, the most stale users are served first rather than the
+    lowest athlete_ids being served every time.
+
+    Degrades in two steps if columns are missing, so deploying this Lambda
+    before migration 016 has run is safe rather than merely survivable:
+      1. Full query (needs 011/015/016).
+      2. Sweep clause dropped, webhook-freshness filter kept (needs 011/015).
+         Keeping the filter matters — dropping straight to "all connected users"
+         would poll everyone every hour and multiply Strava read usage by 6x.
+      3. All connected users (no migrations needed).
     """
     sql_with_filter = f"""
+    SELECT athlete_id, access_token, refresh_token, expires_at,
+      (
+        profile_picture_updated_at IS NULL
+        OR profile_picture_updated_at < NOW() - INTERVAL '{PROFILE_PIC_REFRESH_SECONDS} seconds'
+      ) AS profile_pic_stale
+    FROM users
+    WHERE access_token IS NOT NULL
+      AND refresh_token IS NOT NULL
+      AND (
+        last_webhook_received_at IS NULL
+        OR last_webhook_received_at < NOW() - INTERVAL '{WEBHOOK_FRESHNESS_SECONDS} seconds'
+        OR last_metadata_refresh_at IS NULL
+        OR last_metadata_refresh_at < NOW() - INTERVAL '{METADATA_REFRESH_SECONDS} seconds'
+      )
+    ORDER BY last_metadata_refresh_at ASC NULLS FIRST, athlete_id
+    """
+    # Fallback for before migration 016: same behaviour as before this change.
+    sql_no_sweep = f"""
     SELECT athlete_id, access_token, refresh_token, expires_at,
       (
         profile_picture_updated_at IS NULL
@@ -445,8 +510,8 @@ def get_users_needing_poll():
       )
     ORDER BY athlete_id
     """
-    # Fallback for before migrations 011/015 have run. Marks pictures as
-    # not-stale so we never attempt a refresh against a missing column.
+    # Last-resort fallback for before migrations 011/015 have run. Marks pictures
+    # as not-stale so we never attempt a refresh against a missing column.
     sql_fallback = """
     SELECT athlete_id, access_token, refresh_token, expires_at,
       false AS profile_pic_stale
@@ -458,8 +523,16 @@ def get_users_needing_poll():
     try:
         result = _exec_sql(sql_with_filter)
     except Exception as e:
-        log(f"user poll filter failed ({e}); falling back to all connected users", "WARNING")
-        result = _exec_sql(sql_fallback)
+        log(
+            f"refresh-sweep query failed ({e}); has migration 016 run? "
+            "falling back to webhook-freshness-only selection",
+            "WARNING",
+        )
+        try:
+            result = _exec_sql(sql_no_sweep)
+        except Exception as e2:
+            log(f"webhook-freshness query also failed ({e2}); falling back to all connected users", "WARNING")
+            result = _exec_sql(sql_fallback)
 
     users = []
     for record in result.get("records", []):
@@ -481,12 +554,27 @@ def get_users_needing_poll():
     return users
 
 
+def mark_metadata_refreshed(athlete_id):
+    """Stamp a successful refresh sweep so this user drops out of the due set.
+
+    Non-fatal: pre-migration-016 this column does not exist, in which case the
+    sweep clause in get_users_needing_poll() is inert anyway and behaviour falls
+    back to the previous webhook-freshness-only logic.
+    """
+    try:
+        _exec_sql(
+            "UPDATE users SET last_metadata_refresh_at = now() WHERE athlete_id = :aid",
+            [{"name": "aid", "value": {"longValue": athlete_id}}],
+        )
+    except Exception as e:
+        log(f"Failed to stamp last_metadata_refresh_at for {athlete_id}: {e}", "WARNING")
+
+
 def update_recent_activities_for_user(user, context=None):
     """Update recent activities for a single user.
 
-    The per-user `/athlete` profile call has been removed: it doubled the
-    rate-limit budget for no functional benefit (profile pics are not
-    time-sensitive). Re-add it as a separate, less-frequent job if needed.
+    Costs one Strava read request (the activities list), plus one more only when
+    the athlete's profile picture is stale enough to warrant a re-fetch.
     """
     athlete_id = user["athlete_id"]
     access_token = user["access_token"]
@@ -504,11 +592,25 @@ def update_recent_activities_for_user(user, context=None):
         after_timestamp = max(ACTIVITIES_START_DATE, current_time - UPDATE_WINDOW_SECONDS)
 
         # Fetch recent activities
-        activities = fetch_strava_activities(access_token, after_timestamp, context=context)
+        activities = fetch_strava_activities(
+            access_token, after_timestamp, context=context, per_page=ACTIVITIES_PER_PAGE
+        )
 
         if not isinstance(activities, list):
             log(f"Unexpected response from Strava API for user {athlete_id}: {type(activities)}", "ERROR")
             return {"athlete_id": athlete_id, "success": False, "error": "Invalid API response"}
+
+        # A full page means the window may hold activities we did not fetch, so
+        # the tail of the window went unrefreshed. Surface it rather than
+        # silently capping — 200 activities in the window is implausible today,
+        # but this is the line that tells us if that ever stops being true.
+        if len(activities) >= ACTIVITIES_PER_PAGE:
+            log(
+                f"User {athlete_id}: page full ({len(activities)} activities); "
+                f"activities beyond page 1 of the {UPDATE_WINDOW_SECONDS // 86400}-day "
+                "window were NOT refreshed",
+                "WARNING",
+            )
 
         # Store activities
         stored_count = 0
@@ -528,6 +630,10 @@ def update_recent_activities_for_user(user, context=None):
         # PROFILE_PIC_REFRESH_SECONDS so the extra read request stays cheap.
         if user.get("profile_pic_stale"):
             refresh_profile_picture(athlete_id, access_token, context=context)
+
+        # Only stamp on a clean pass. A failure leaves the user due so the next
+        # run retries instead of waiting out a full sweep interval.
+        mark_metadata_refreshed(athlete_id)
 
         return {
             "athlete_id": athlete_id,
@@ -575,9 +681,10 @@ def handler(event, context):
     """
     Lambda handler for scheduled activity updates.
 
-    Runs every hour as a backstop for missed webhooks. Two execution modes:
+    Runs every hour as a backstop for missed webhooks and as a metadata refresh
+    sweep. Two execution modes:
       1. Scheduled invoke (no `continue_athlete_ids` in event): pulls connected
-         users that webhooks have not kept fresh recently, processes the first
+         users that are due (webhook-stale or sweep-due), processes the first
          USERS_PER_INVOCATION, and self-invokes for the rest.
       2. Continuation invoke (`continue_athlete_ids` in event): processes only
          the supplied athlete IDs and self-invokes again if needed.
@@ -605,9 +712,9 @@ def handler(event, context):
             users = [u for u in all_users if u["athlete_id"] in id_set]
             log(f"Resolved {len(users)} of {len(continue_ids)} continuation IDs to active users", "INFO")
         else:
-            log("Fetching connected users that webhooks have not kept fresh...", "INFO")
+            log("Fetching connected users due for a poll or refresh sweep...", "INFO")
             users = get_users_needing_poll()
-            log(f"Found {len(users)} users to poll (webhook-stale or never-webhooked)", "INFO")
+            log(f"Found {len(users)} users to poll (webhook-stale or refresh-sweep due)", "INFO")
 
         if not users:
             end_time = datetime.utcnow()

--- a/backend/test_activity_upsert_consistency.py
+++ b/backend/test_activity_upsert_consistency.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Guard the activity upsert contract across every ingest Lambda.
+
+Seven Lambdas write to the activities table with near-identical ON CONFLICT
+upserts. That duplication is where things quietly drift: webhook_processor --
+the primary real-time path -- omitted athlete_count entirely, so group
+activities ingested via webhook were pinned to the column default of 1 and the
+group badge never rendered. Nothing failed; the field was simply never written.
+
+These tests read the SQL out of each Lambda and assert the shared contract, so
+the next divergence fails here instead of silently producing wrong data.
+
+Pure text analysis: no boto3, no AWS, no database. Run directly:
+    python3 backend/test_activity_upsert_consistency.py
+"""
+
+import io
+import os
+import re
+import sys
+
+BACKEND_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Lambdas that read Strava's *list* endpoint (/athlete/activities). Its
+# SummaryActivity carries map.summary_polyline only -- never the full polyline.
+SUMMARY_SOURCE_LAMBDAS = [
+    "fetch_activities",
+    "scheduled_activity_update",
+    "update_activities",
+    "user_update_activities",
+    "admin_update_activities",
+    "admin_backfill_activities",
+]
+
+# Lambdas that read Strava's *detail* endpoint (/activities/{id}), which does
+# carry the full polyline.
+DETAIL_SOURCE_LAMBDAS = [
+    "webhook_processor",
+]
+
+ALL_UPSERT_LAMBDAS = SUMMARY_SOURCE_LAMBDAS + DETAIL_SOURCE_LAMBDAS
+
+# Fields Strava can change after upload, so every path must write them on
+# conflict or stale values survive forever.
+MUTABLE_FIELDS = [
+    "name",             # renames
+    "type",             # re-typing a Run as a Walk, etc.
+    "athlete_count",    # grows as other participants upload a group activity
+    "distance",
+    "moving_time",
+    "elapsed_time",
+    "total_elevation_gain",
+]
+
+# Values computed by our own trail-matching, never sourced from Strava. These
+# must be preserved on conflict, not clobbered by the incoming NULL.
+COMPUTED_FIELDS = ["time_on_trail", "distance_on_trail"]
+
+
+def _read_lambda(name):
+    path = os.path.join(BACKEND_DIR, name, "lambda_function.py")
+    with io.open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _strip_sql_comments(sql):
+    """Drop -- line comments so they can't satisfy an assertion by accident."""
+    return re.sub(r"--[^\n]*", "", sql)
+
+
+def _extract_do_update_block(source, lambda_name):
+    """Return the DO UPDATE SET body of the activities upsert, comments stripped."""
+    match = re.search(
+        r"INSERT INTO activities.*?DO UPDATE SET(.*?)(?:RETURNING|\"\"\")",
+        source,
+        re.DOTALL,
+    )
+    assert match, f"{lambda_name}: could not locate an activities DO UPDATE SET block"
+    return _strip_sql_comments(match.group(1))
+
+
+def _assignment_for(block, column):
+    """Return the right-hand side assigned to `column`, or None if unassigned."""
+    match = re.search(rf"(?<![\w.]){re.escape(column)}\s*=\s*([^,\n]+)", block)
+    return match.group(1).strip() if match else None
+
+
+def test_mutable_fields_are_written_by_every_path():
+    """Every ingest path must refresh all Strava-mutable fields."""
+    print("Testing that all mutable fields are written on conflict...")
+    for name in ALL_UPSERT_LAMBDAS:
+        block = _extract_do_update_block(_read_lambda(name), name)
+        for column in MUTABLE_FIELDS:
+            assigned = _assignment_for(block, column)
+            assert assigned is not None, (
+                f"{name}: '{column}' is never written in DO UPDATE SET. Strava can "
+                f"change it after upload, so omitting it strands stale data."
+            )
+            assert "EXCLUDED" in assigned, (
+                f"{name}: '{column}' is assigned '{assigned}', which does not take "
+                f"the incoming Strava value."
+            )
+        print(f"  ✓ {name}: all {len(MUTABLE_FIELDS)} mutable fields written")
+
+
+def test_computed_trail_fields_are_preserved():
+    """Trail metrics are ours, not Strava's -- an upsert must not clear them."""
+    print("Testing that computed trail metrics survive an upsert...")
+    for name in ALL_UPSERT_LAMBDAS:
+        block = _extract_do_update_block(_read_lambda(name), name)
+        for column in COMPUTED_FIELDS:
+            assigned = _assignment_for(block, column)
+            if assigned is None:
+                continue  # Not touching the column at all also preserves it.
+            assert assigned.startswith("COALESCE(activities."), (
+                f"{name}: '{column}' is assigned '{assigned}'. It must be "
+                f"COALESCE(activities.{column}, ...) or omitted, otherwise a "
+                f"refresh wipes trail matching results."
+            )
+        print(f"  ✓ {name}: trail metrics preserved")
+
+
+def test_summary_polyline_never_overwrites_full_polyline():
+    """The list endpoint's summary polyline must not downgrade a stored full one."""
+    print("Testing polyline downgrade protection...")
+    for name in SUMMARY_SOURCE_LAMBDAS:
+        block = _extract_do_update_block(_read_lambda(name), name)
+        assigned = _assignment_for(block, "polyline")
+        assert assigned is not None, f"{name}: 'polyline' unexpectedly unassigned"
+        assert assigned.startswith("COALESCE(activities.polyline"), (
+            f"{name}: reads the Strava list endpoint (summary_polyline only) but "
+            f"assigns polyline = '{assigned}'. That overwrites the full polyline "
+            f"stored from the detail endpoint. Use "
+            f"COALESCE(activities.polyline, EXCLUDED.polyline)."
+        )
+        print(f"  ✓ {name}: summary polyline cannot downgrade a full one")
+
+    for name in DETAIL_SOURCE_LAMBDAS:
+        block = _extract_do_update_block(_read_lambda(name), name)
+        assigned = _assignment_for(block, "polyline")
+        assert assigned == "EXCLUDED.polyline", (
+            f"{name}: reads the Strava detail endpoint, so it should assign "
+            f"polyline = EXCLUDED.polyline to upgrade a stored summary polyline, "
+            f"but assigns '{assigned}'."
+        )
+        print(f"  ✓ {name}: detail polyline upgrades the stored value")
+
+
+def test_athlete_count_bind_parameter_is_supplied():
+    """A column in the SQL is useless if no parameter is bound to it."""
+    print("Testing that athlete_count is extracted and bound...")
+    for name in ALL_UPSERT_LAMBDAS:
+        source = _read_lambda(name)
+        assert 'activity.get("athlete_count"' in source, (
+            f"{name}: never reads athlete_count off the Strava payload."
+        )
+        assert re.search(r'"name":\s*"ac"', source), (
+            f"{name}: no ':ac' bind parameter supplied for athlete_count."
+        )
+        print(f"  ✓ {name}: athlete_count extracted and bound")
+
+
+def test_athlete_count_defaults_to_one():
+    """Strava omits athlete_count on some payloads; a solo activity means 1."""
+    print("Testing athlete_count default...")
+    for name in ALL_UPSERT_LAMBDAS:
+        source = _read_lambda(name)
+        assert re.search(r'activity\.get\("athlete_count",\s*1\)', source), (
+            f"{name}: athlete_count must default to 1 when Strava omits it, "
+            f"otherwise the bind parameter receives None and the insert fails."
+        )
+        print(f"  ✓ {name}: defaults to 1")
+
+
+def main():
+    tests = [
+        test_mutable_fields_are_written_by_every_path,
+        test_computed_trail_fields_are_preserved,
+        test_summary_polyline_never_overwrites_full_polyline,
+        test_athlete_count_bind_parameter_is_supplied,
+        test_athlete_count_defaults_to_one,
+    ]
+
+    print("=" * 72)
+    print("Activity upsert consistency tests")
+    print("=" * 72)
+
+    failures = []
+    for test in tests:
+        try:
+            test()
+        except AssertionError as e:
+            failures.append(f"{test.__name__}: {e}")
+            print(f"  ✗ FAILED: {e}")
+        print()
+
+    print("=" * 72)
+    if failures:
+        print(f"❌ {len(failures)} test(s) failed:")
+        for failure in failures:
+            print(f"  - {failure}")
+        print("=" * 72)
+        return 1
+
+    print("✅ All activity upsert consistency tests passed!")
+    print("=" * 72)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/update_activities/lambda_function.py
+++ b/backend/update_activities/lambda_function.py
@@ -228,6 +228,10 @@ def store_activity(athlete_id, activity):
     # Note: time_on_trail and distance_on_trail are computed separately by trail matching logic
     # We initialize them as NULL and preserve existing values on update using COALESCE
     # This ensures computed trail metrics aren't accidentally overwritten during activity updates
+    # polyline is COALESCEd, not overwritten: this reads Strava's list endpoint,
+    # whose SummaryActivity carries only map.summary_polyline. Assigning it
+    # directly would downgrade a full polyline stored by webhook_processor from
+    # the detail endpoint. COALESCE still fills the column when it is empty.
     sql = """
     INSERT INTO activities (
         athlete_id, strava_activity_id, name, distance, moving_time, elapsed_time,
@@ -246,7 +250,7 @@ def store_activity(athlete_id, activity):
         start_date = EXCLUDED.start_date,
         start_date_local = EXCLUDED.start_date_local,
         timezone = EXCLUDED.timezone,
-        polyline = EXCLUDED.polyline,
+        polyline = COALESCE(activities.polyline, EXCLUDED.polyline),
         athlete_count = EXCLUDED.athlete_count,
         time_on_trail = COALESCE(activities.time_on_trail, EXCLUDED.time_on_trail),
         distance_on_trail = COALESCE(activities.distance_on_trail, EXCLUDED.distance_on_trail),

--- a/backend/user_update_activities/lambda_function.py
+++ b/backend/user_update_activities/lambda_function.py
@@ -39,6 +39,13 @@ ACTIVITIES_START_DATE = 1767225600
 # Token refresh buffer - refresh tokens 5 minutes before expiry
 TOKEN_REFRESH_BUFFER_SECONDS = 300
 
+# Pagination. This endpoint is the user's full-season repair button, so it must
+# walk every page rather than stopping at the first. 200 is Strava's per-page
+# maximum; MAX_PAGES bounds the work at 2,000 activities per press, comfortably
+# above a season's worth while still capping Lambda runtime and rate-limit burn.
+ACTIVITIES_PER_PAGE = 200
+MAX_PAGES = 10
+
 
 def get_cors_origin():
     """Extract origin (scheme + host) from FRONTEND_URL for CORS headers"""
@@ -321,6 +328,10 @@ def store_activity(athlete_id, activity):
     # Note: time_on_trail and distance_on_trail are computed separately by trail matching logic
     # We initialize them as NULL and preserve existing values on update using COALESCE
     # This ensures computed trail metrics aren't accidentally overwritten during activity updates
+    # polyline is COALESCEd, not overwritten: this reads Strava's list endpoint,
+    # whose SummaryActivity carries only map.summary_polyline. Assigning it
+    # directly would downgrade a full polyline stored by webhook_processor from
+    # the detail endpoint. COALESCE still fills the column when it is empty.
     sql = """
     INSERT INTO activities (
         athlete_id, strava_activity_id, name, distance, moving_time, elapsed_time,
@@ -339,7 +350,7 @@ def store_activity(athlete_id, activity):
         start_date = EXCLUDED.start_date,
         start_date_local = EXCLUDED.start_date_local,
         timezone = EXCLUDED.timezone,
-        polyline = EXCLUDED.polyline,
+        polyline = COALESCE(activities.polyline, EXCLUDED.polyline),
         athlete_count = EXCLUDED.athlete_count,
         time_on_trail = COALESCE(activities.time_on_trail, EXCLUDED.time_on_trail),
         distance_on_trail = COALESCE(activities.distance_on_trail, EXCLUDED.distance_on_trail),
@@ -371,46 +382,77 @@ def store_activity(athlete_id, activity):
         return False
 
 
-def update_user_activities(athlete_id, per_page=200):
-    """Update activities for the authenticated user"""
+def update_user_activities(athlete_id, per_page=ACTIVITIES_PER_PAGE):
+    """Update activities for the authenticated user.
+
+    Walks every page of the athlete's activities since ACTIVITIES_START_DATE.
+    This previously fetched page 1 only, which silently skipped everything past
+    the first 200 activities — so for any athlete with more than that in the
+    season, part of their history could never be repaired by this endpoint, and
+    nothing in the response said so.
+    """
     print(f"Updating activities for user {athlete_id}")
-    
+
     # Get user tokens
     access_token, refresh_token, expires_at = get_user_tokens(athlete_id)
-    
+
     if not access_token or not refresh_token:
         raise ValueError(f"User {athlete_id} not found or not connected to Strava")
-    
+
     # Ensure token is valid
     access_token = ensure_valid_token(athlete_id, access_token, refresh_token, expires_at)
-    
+
     athlete_profile = fetch_strava_athlete(access_token)
     if athlete_profile:
         update_user_profile_picture(athlete_id, athlete_profile)
-    
-    # Fetch activities from Strava - get first page only
-    activities = fetch_strava_activities(access_token, per_page=per_page, page=1)
-    
-    if not isinstance(activities, list):
-        raise RuntimeError(f"Unexpected response from Strava API: {type(activities)}")
-    
-    # Store activities in database
+
     stored_count = 0
     failed_count = 0
-    
-    for activity in activities:
-        if store_activity(athlete_id, activity):
-            stored_count += 1
-        else:
-            failed_count += 1
-    
-    return {
+    total_fetched = 0
+    truncated = False
+
+    for page in range(1, MAX_PAGES + 1):
+        activities = fetch_strava_activities(access_token, per_page=per_page, page=page)
+
+        if not isinstance(activities, list):
+            raise RuntimeError(f"Unexpected response from Strava API: {type(activities)}")
+
+        if not activities:
+            break
+
+        total_fetched += len(activities)
+
+        for activity in activities:
+            if store_activity(athlete_id, activity):
+                stored_count += 1
+            else:
+                failed_count += 1
+
+        # A short page is the last page.
+        if len(activities) < per_page:
+            break
+
+        if page == MAX_PAGES:
+            truncated = True
+            print(
+                f"WARNING: hit MAX_PAGES ({MAX_PAGES}) for athlete {athlete_id} after "
+                f"{total_fetched} activities; older activities were NOT updated"
+            )
+
+    result = {
         "message": "Activities updated successfully",
         "athlete_id": athlete_id,
-        "total_activities": len(activities),
+        "total_activities": total_fetched,
         "stored": stored_count,
-        "failed": failed_count
+        "failed": failed_count,
+        "truncated": truncated,
     }
+    if truncated:
+        result["message"] = (
+            f"Activities updated, but stopped at the {MAX_PAGES}-page limit "
+            f"({total_fetched} activities). Run again to continue."
+        )
+    return result
 
 
 def handler(event, context):

--- a/backend/webhook_processor/lambda_function.py
+++ b/backend/webhook_processor/lambda_function.py
@@ -334,7 +334,8 @@ def store_activity(athlete_id, activity):
     start_date = activity.get("start_date", "")
     start_date_local = activity.get("start_date_local", "")
     timezone = activity.get("timezone", "")
-    
+    athlete_count = activity.get("athlete_count", 1)  # Default to 1 for solo activities
+
     # Get polyline from map - prefer full polyline over summary_polyline
     polyline = ""
     if activity.get("map"):
@@ -345,10 +346,11 @@ def store_activity(athlete_id, activity):
     sql = """
     INSERT INTO activities (
         athlete_id, strava_activity_id, name, distance, moving_time, elapsed_time,
-        total_elevation_gain, type, start_date, start_date_local, timezone, polyline, updated_at
+        total_elevation_gain, type, start_date, start_date_local, timezone, polyline,
+        athlete_count, updated_at
     )
-    VALUES (:aid, :sid, :name, :dist, :mt, :et, :elev, :type, CAST(:sd AS TIMESTAMP), CAST(:sdl AS TIMESTAMP), :tz, :poly, now())
-    ON CONFLICT (athlete_id, strava_activity_id) 
+    VALUES (:aid, :sid, :name, :dist, :mt, :et, :elev, :type, CAST(:sd AS TIMESTAMP), CAST(:sdl AS TIMESTAMP), :tz, :poly, :ac, now())
+    ON CONFLICT (athlete_id, strava_activity_id)
     DO UPDATE SET
         name = EXCLUDED.name,
         distance = EXCLUDED.distance,
@@ -360,6 +362,7 @@ def store_activity(athlete_id, activity):
         start_date_local = EXCLUDED.start_date_local,
         timezone = EXCLUDED.timezone,
         polyline = EXCLUDED.polyline,
+        athlete_count = EXCLUDED.athlete_count,
         updated_at = now()
     RETURNING id
     """
@@ -377,8 +380,9 @@ def store_activity(athlete_id, activity):
         {"name": "sdl", "value": {"stringValue": start_date_local} if start_date_local else {"isNull": True}},
         {"name": "tz", "value": {"stringValue": timezone}},
         {"name": "poly", "value": {"stringValue": polyline} if polyline else {"isNull": True}},
+        {"name": "ac", "value": {"longValue": athlete_count}},
     ]
-    
+
     try:
         result = _exec_sql(sql, params)
         # Get the returned activity ID


### PR DESCRIPTION
## Problem

Strava keeps mutating activities **after** they are uploaded, and nothing in the pipeline reliably picked that up:

- **`athlete_count` grows as the *other* participants upload** their copy of a group activity — minutes to days later. Any write-once-at-ingest design is wrong by construction.
- **Athletes rename and re-type activities** long after the fact.

Two things combined so that for the *most active* users, `athlete_count` was never correct:

1. **`webhook_processor` never wrote `athlete_count` at all.** It already fetched the `/activities/{id}` detail payload containing the value and dropped it. Migration `006` defaults the column to `1`, so webhook-ingested rows were pinned to `1` and the group badge never rendered. Nothing failed — the field was simply never written. Every other ingest lambda did set it.
2. **The hourly poll skipped webhook-fresh users.** It filtered to `last_webhook_received_at < NOW() - 6 hours`, so users whose webhooks were flowing were never polled — and its window was only 24 hours. A working webhook pipeline therefore *guaranteed* a stale `athlete_count`, and a single missed webhook (subscription lapse, DLQ, rate-limit deferral) left a row stale permanently.

Renames were mostly fine — every path re-fetches the whole activity rather than applying the webhook's `updates` delta, so `name = EXCLUDED.name` propagates. But they shared gap #2: a rename on an activity older than 24 hours, after a missed webhook, was never reconciled.

## Changes

| File | Change |
| --- | --- |
| `webhook_processor` | Write `athlete_count` (the one field it was missing) |
| `scheduled_activity_update` | 7-day lookback; refresh sweep over **all** connected users |
| `migrations/016` | New `users.last_metadata_refresh_at` |
| `user_update_activities` | Paginate instead of fetching page 1 only |
| `fetch_activities`, `update_activities`, `admin_update_activities`, `admin_backfill_activities` | Polyline downgrade fix |
| `test_activity_upsert_consistency.py` | New regression test |

### The refresh sweep

A user is now polled when they are webhook-stale **or** their sweep is due (`last_metadata_refresh_at` older than 6h, or never), ordered oldest-sweep-first so a backlog drains fairly. Stamped only on a clean pass, so a failure retries next run rather than waiting out a full interval.

Widening the window from 24 hours to 7 days is **free** — it is the same single list request either way. `GET /athlete/activities` returns `athlete_count` on every SummaryActivity, so one request per user reconciles a whole week. That is ~25x cheaper than `backfill_athlete_count`, which spends one *detail* request per activity (100 requests to fix 100 activities, a third of the daily read quota per user, with no rate-limit handling at all — a 429 there just logs and moves on).

**Rate limit budget:** 1 read per user per 6h = 4/user/day, inside Strava's 3,000/day read quota up to ~700 users. If we outgrow it, raise `METADATA_REFRESH_SECONDS` rather than shrinking the window.

No EventBridge, IAM, env var, or GitHub secret changes — the existing `scheduled-activity-update-hourly` rule is reused.

### Polyline downgrade fix

The list endpoint returns only `map.summary_polyline`, never the full polyline. All six list-based lambdas were assigning `polyline = EXCLUDED.polyline`, so every refresh **downgraded** any full polyline `webhook_processor` had stored from the detail endpoint. Already happening hourly to the last 24h; widening to 7 days would have extended it. Now `COALESCE(activities.polyline, EXCLUDED.polyline)` — still fills the column when empty, never trades detail for summary. `webhook_processor` keeps direct assignment so it can still *upgrade* a stored summary polyline.

Trade-off: if an athlete crops a route, the refreshed summary polyline is ignored here; the update webhook corrects it.

### Pagination

`user_update_activities` fetched page 1 only (the comment even said so). With `ACTIVITIES_START_DATE` at Jan 1 2026, an athlete averaging one activity a day has ~227 in range, so 27+ were unreachable by the button — silently, with nothing in the response saying so. Now walks all pages, bounded at `MAX_PAGES = 10` (2,000 activities), and reports `truncated: true` with a message telling the user to press again.

## Testing

`backend/test_activity_upsert_consistency.py` reads the SQL out of all seven ingest lambdas and asserts the shared contract: every Strava-mutable field is written, computed trail metrics are preserved, summary polylines cannot downgrade full ones, and `athlete_count` is both bound and defaulted.

Verified it has teeth — reverting the one-line `athlete_count` fix reproduces the original bug as a failure:

```
✗ FAILED: webhook_processor: 'athlete_count' is never written in DO UPDATE SET.
```

All runnable backend tests pass (`test_activity_upsert_consistency`, `fetch_activities/test_athlete_count`, `test_polyline`, `test_pagination`, `test_admin_utils`). `update_activities/test_lambda.py` fails to import `boto3` — pre-existing and environmental, not related to this change.

## Deployment

Full steps in **`DEPLOYMENT_ACTIVITY_METADATA_REFRESH.md`**, including verification queries and rollback. Summary:

1. **Run migration 016 first** (idempotent).
2. Merge — `deploy-lambdas.yml` deploys all seven functions on push to `main`.
3. Verify the sweep: CloudWatch should show `Found N users to poll (webhook-stale or refresh-sweep due)` and `Rate limit usage` well under 300; `count(last_metadata_refresh_at)` should climb toward the connected-user count over a few hours.
4. **One-time repair for rows older than 7 days** via `admin_update_activities` — the sweep only covers the last 7 days.

Deploying ahead of the migration is safe, not merely survivable: `get_users_needing_poll()` degrades in two steps, dropping the sweep clause but **keeping** the webhook-freshness filter. Falling straight through to "all connected users" would have polled everyone hourly and multiplied read usage ~6x.

Rollback is a revert; leave the column in place (additive, nothing else reads it).

## Not fixed (called out so it does not read as covered)

- **Re-typing an activity can change leaderboard eligibility, and no recompute is triggered.** `activities.type` is refreshed, but `leaderboard_agg` is only recomputed by trail matching and the webhook delete path. Pre-existing; worth a follow-up.
- **Strava athlete deauthorization is still ignored** — `webhook/lambda_function.py` drops `object_type != "activity"`, so an `athlete` event with `updates: {authorized: "false"}` is discarded and the user stays marked connected until a token refresh fails. Pre-existing, unrelated.
- `backfill_athlete_count` still has no schedule and still lacks a `WHERE athlete_count IS NULL` clause and rate-limit handling. Intentionally left as-is: the sweep supersedes it for routine use, and the deployment doc now steers one-time repairs to the much cheaper list-endpoint path instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)